### PR TITLE
docs: readme: Add information about Discord channel

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![Crate](https://img.shields.io/crates/v/lockc)](https://crates.io/crates/lockc)
 [![Docs](https://docs.rs/lockc/badge.svg)](https://docs.rs/lockc/)
+[![Discord](https://img.shields.io/discord/874314181191565453)](https://discord.gg/799cmsYB4q)
 [![Build Status](https://github.com/rancher-sandbox/lockc/actions/workflows/rust.yml/badge.svg)](https://github.com/rancher-sandbox/lockc/actions/workflows/rust.yml)
 
 **lockc** is open source sofware for providing MAC (Mandatory Access Control)
@@ -19,3 +20,6 @@ production environment and without any official binaries or packages to use -
 currently the only way to use it is building from sources.
 
 See [the full documentation here](https://docs.rs/lockc/).
+
+If you need help or want to talk with contributors, plese come chat with us
+on `#lockc` channel on the [Rust Cloud Native Discord server](https://discord.gg/799cmsYB4q).

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,9 @@
 //! packages to use, except of a Rust crate. Currently the most convenient way
 //! to use it is to use the source code and follow the guide.
 //!
+//! If you need help or want to talk with contributors, please come chat with
+//! us on `#lockc` channel on the [Rust Cloud Native Discord server](https://discord.gg/799cmsYB4q).
+//!
 //! ## Architecture
 //!
 //! The project consists of 3 parts:


### PR DESCRIPTION
Add a widget and mentions abot the #lockc channel on the Rust Cloud
Native server.

Signed-off-by: Michal Rostecki <mrostecki@opensuse.org>