### PR TITLE
Update libbpf-cargo requirement from 0.7 to 0.9

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,5 +37,5 @@ uuid = { version = "0.8", default-features = false, features = ["v4"] }
 
 [build-dependencies]
 anyhow = "1.0"
-libbpf-cargo = "0.7"
+libbpf-cargo = "0.9"
 thiserror = "1.0"


### PR DESCRIPTION
Apparently dependabot can't rebase sometimes, lol

Updates the requirements on [libbpf-cargo](https://github.com/libbpf/libbpf-rs) to permit the latest version.
- [Release notes](https://github.com/libbpf/libbpf-rs/releases)
- [Commits](https://github.com/libbpf/libbpf-rs/commits)

---
updated-dependencies:
- dependency-name: libbpf-cargo
  dependency-type: direct:production
...

Signed-off-by: dependabot[bot] <support@github.com>