### PR TITLE
readme: Link to the mdbook

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 # lockc
 
 [![Crate](https://img.shields.io/crates/v/lockc)](https://crates.io/crates/lockc)
-[![Docs](https://docs.rs/lockc/badge.svg)](https://docs.rs/lockc/)
+[![Book](https://img.shields.io/website?url=https%3A%2F%2Francher-sandbox.github.io%2Flockc%2F)](https://rancher-sandbox.github.io/lockc/)
 [![Discord](https://img.shields.io/discord/874314181191565453)](https://discord.gg/799cmsYB4q)
+[![Docs](https://docs.rs/lockc/badge.svg)](https://docs.rs/lockc/)
 [![Build Status](https://github.com/rancher-sandbox/lockc/actions/workflows/rust.yml/badge.svg)](https://github.com/rancher-sandbox/lockc/actions/workflows/rust.yml)
 
 **lockc** is open source sofware for providing MAC (Mandatory Access Control)
@@ -19,7 +20,8 @@ Please note that currently lockc is an experimental project, not meant for
 production environment and without any official binaries or packages to use -
 currently the only way to use it is building from sources.
 
-See [the full documentation here](https://docs.rs/lockc/).
+See [the full documentation here](https://rancher-sandbox.github.io/lockc/).
+And [the code documentation here](https://docs.rs/lockc/).
 
 If you need help or want to talk with contributors, plese come chat with us
 on `#lockc` channel on the [Rust Cloud Native Discord server](https://discord.gg/799cmsYB4q).


### PR DESCRIPTION
This change links to the mdbook as the main website / documentation,
while keeping the docs.rs link as the secondary one.

Signed-off-by: Michal Rostecki <mrostecki@opensuse.org>