### PR TITLE
docs: Add demos with mount policies on Kubernetes

### DIFF
--- a/contrib/terraform/libvirt/cloud-init/control-plane.tpl
+++ b/contrib/terraform/libvirt/cloud-init/control-plane.tpl
@@ -2,3 +2,7 @@
   - mkdir -p /home/opensuse/.kube
   - sudo cp -i /etc/kubernetes/admin.conf /home/opensuse/.kube/config
   - sudo chown opensuse /home/opensuse/.kube/config
+%{ if workers == "0" }
+  - export KUBECONFIG=/etc/kubernetes/admin.conf
+  - kubectl taint nodes $(kubectl get nodes --selector=node-role.kubernetes.io/master | awk 'FNR==2{print $1}') node-role.kubernetes.io/master-
+%{ endif }

--- a/contrib/terraform/libvirt/control-plane.tf
+++ b/contrib/terraform/libvirt/control-plane.tf
@@ -7,6 +7,10 @@ resource "libvirt_volume" "control_plane" {
 
 data "template_file" "control_plane_commands" {
   template = file("cloud-init/control-plane.tpl")
+
+  vars = {
+    workers = var.workers
+  }
 }
 
 data "template_file" "control_plane_cloud_init" {

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -15,3 +15,5 @@
 - [Policies](policies/README.md)
     - [Mount](policies/mount.md)
     - [Syslog](policies/syslog.md)
+- [Demos](demos/README.md)
+    - [Mount](demos/mount.md)

--- a/docs/src/demos/README.md
+++ b/docs/src/demos/README.md
@@ -1,0 +1,5 @@
+# Demos
+
+This section of the book contains demos.
+
+- [Mount](mount.md) - mount policies

--- a/docs/src/demos/mount.md
+++ b/docs/src/demos/mount.md
@@ -1,0 +1,19 @@
+## Mount policies
+
+### Kubernetes
+
+The following demo shows mount policies being enforced on Kubernetes pods.
+
+YAML files can be found [here](https://github.com/rancher-sandbox/lockc/tree/main/examples/kubernetes).
+
+The policy violations in [deployments-should-fail.yaml](https://github.com/rancher-sandbox/lockc/tree/main/examples/kubernetes/deployments-should-fail.yaml)
+file are:
+
+- *nginx-restricted-fail* deployment trying to make a host mount while having a
+  **restricted** policy
+- *bpf-default-fail* and *bpf-baseline-fail* deployment trying to mount
+  `/sys/fs/bpf` while having a **baseline** policy
+- *bpf-restricted-fail* trying to mount `/sys/fs/bpf` while having a
+  **restricted** policy.
+
+[![asciicast](https://asciinema.org/a/sUxMMB5BKkJzlF1jP6k8Bxab3.svg)](https://asciinema.org/a/sUxMMB5BKkJzlF1jP6k8Bxab3)

--- a/docs/src/policies/README.md
+++ b/docs/src/policies/README.md
@@ -1,4 +1,4 @@
-## Policies
+# Policies
 
 lockc provides three policy levels for containers:
 

--- a/examples/kubernetes/deployments-should-fail.yaml
+++ b/examples/kubernetes/deployments-should-fail.yaml
@@ -1,0 +1,118 @@
+# Deployments which should fail to run as they violate policy levels of their
+# namespaces.
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-restricted-fail
+  namespace: restricted
+spec:
+  selector:
+    matchLabels:
+      app: nginx-restricted-fail
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: nginx-restricted-fail
+    spec:
+      containers:
+      - name: nginx
+        image: nginx:1.14.2
+        ports:
+        - containerPort: 80
+        volumeMounts:
+        - name: data
+          mountPath: /var/data/www
+      volumes:
+      - name: data
+        hostPath:
+          path: /var/data/www
+          type: Directory
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: bpf-default-fail
+  namespace: default
+spec:
+  selector:
+    matchLabels:
+      app: bpf-default-fail
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: bpf-default-fail
+    spec:
+      containers:
+      - name: bpf
+        image: busybox:latest
+        command: ["sleep"]
+        args: ["inf"]
+        volumeMounts:
+        - name: bpffs
+          mountPath: /sys/fs/bpf
+      volumes:
+      - name: bpffs
+        hostPath:
+          path: /sys/fs/bpf
+          type: Directory
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: bpf-restricted-fail
+  namespace: restricted
+spec:
+  selector:
+    matchLabels:
+      app: bpf-restricted-fail
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: bpf-restricted-fail
+    spec:
+      containers:
+      - name: bpf
+        image: busybox:latest
+        command: ["sleep"]
+        args: ["inf"]
+        volumeMounts:
+        - name: bpffs
+          mountPath: /sys/fs/bpf
+      volumes:
+      - name: bpffs
+        hostPath:
+          path: /sys/fs/bpf
+          type: Directory
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: bpf-baseline-fail
+  namespace: baseline
+spec:
+  selector:
+    matchLabels:
+      app: bpf-baseline-fail
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: bpf-baseline-fail
+    spec:
+      containers:
+      - name: bpf
+        image: busybox:latest
+        command: ["sleep"]
+        args: ["inf"]
+        volumeMounts:
+        - name: bpffs
+          mountPath: /sys/fs/bpf
+      volumes:
+      - name: bpffs
+        hostPath:
+          path: /sys/fs/bpf
+          type: Directory

--- a/examples/kubernetes/deployments-should-succeed.yaml
+++ b/examples/kubernetes/deployments-should-succeed.yaml
@@ -1,0 +1,94 @@
+# Deployments which should run successfully as they should not violate policy
+# levels of their namespaces.
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-default
+  namespace: default
+spec:
+  selector:
+    matchLabels:
+      app: nginx-default
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: nginx-default
+    spec:
+      containers:
+      - name: nginx
+        image: nginx:1.14.2
+        ports:
+        - containerPort: 80
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-restricted
+  namespace: restricted
+spec:
+  selector:
+    matchLabels:
+      app: nginx-restricted
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: nginx-restricted
+    spec:
+      containers:
+      - name: nginx
+        image: nginx:1.14.2
+        ports:
+        - containerPort: 80
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-baseline
+  namespace: baseline
+spec:
+  selector:
+    matchLabels:
+      app: nginx-baseline
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: nginx-baseline
+    spec:
+      containers:
+      - name: nginx
+        image: nginx:1.14.2
+        ports:
+        - containerPort: 80
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: bpf-privileged
+  namespace: privileged
+spec:
+  selector:
+    matchLabels:
+      app: bpf-privileged
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: bpf-privileged
+    spec:
+      containers:
+      - name: bpf
+        image: busybox:latest
+        command: ["sleep"]
+        args: ["inf"]
+        volumeMounts:
+        - name: bpffs
+          mountPath: /sys/fs/bpf
+      volumes:
+      - name: bpffs
+        hostPath:
+          path: /sys/fs/bpf
+          type: Directory

--- a/examples/kubernetes/namespaces.yaml
+++ b/examples/kubernetes/namespaces.yaml
@@ -1,0 +1,38 @@
+# Namespaces with pod-security labels which are supported both by lockc and
+# pod-security-admission.
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: restricted
+  labels:
+    pod-security.kubernetes.io/enforce: restricted
+    pod-security.kubernetes.io/enforce-version: v1.22
+    pod-security.kubernetes.io/audit: restricted
+    pod-security.kubernetes.io/audit-version: v1.22
+    pod-security.kubernetes.io/warn: restricted
+    pod-security.kubernetes.io/warn-version: v1.22
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: baseline
+  labels:
+    pod-security.kubernetes.io/enforce: baseline
+    pod-security.kubernetes.io/enforce-version: v1.22
+    pod-security.kubernetes.io/audit: baseline
+    pod-security.kubernetes.io/audit-version: v1.22
+    pod-security.kubernetes.io/warn: baseline
+    pod-security.kubernetes-io/warn-version: v1.22
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: privileged
+  labels:
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/enforce-version: v1.22
+    pod-security.kubernetes.io/audit: privileged
+    pod-security.kubernetes.io/audit-version: v1.22
+    pod-security.kubernetes.io/warn: privileged
+    pod-security.kubernetes-io/warn-version: v1.22


### PR DESCRIPTION
This change adds a demo from asciinema about mount policies being
enforced on Kubernetes pods.

Signed-off-by: Michal Rostecki <mrostecki@opensuse.org>