### PR TITLE
docs: Add "Containers do not contain" section

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,12 +9,18 @@
 **lockc** is open source sofware for providing MAC (Mandatory Access Control)
 type of security audit for container workloads.
 
+The main reason why **lockc** exists is that **containers do not contain**.
+Containers are not as secure and isolated as VMs. By default, they expose
+a lot of information about host OS and provide ways to "break out" from the
+container. **lockc** aims to provide more isolation to containers and make them
+more secure.
+
+The [Containers do not contain](https://rancher-sandbox.github.io/lockc/containers-do-not-cointain.html)
+documentation section explains what we mean by that phrase and what kind of
+behavior we want to restrict with **lockc**.
+
 The main technology behind lockc is [eBPF](https://ebpf.io/) - to be more
 precise, its ability to attach to [LSM hooks](https://www.kernel.org/doc/html/latest/bpf/bpf_lsm.html)
-
-License for eBPF programs: GPLv2
-
-License for userspace part: Apache-2.0
 
 Please note that currently lockc is an experimental project, not meant for
 production environment and without any official binaries or packages to use -
@@ -25,3 +31,8 @@ And [the code documentation here](https://docs.rs/lockc/).
 
 If you need help or want to talk with contributors, plese come chat with us
 on `#lockc` channel on the [Rust Cloud Native Discord server](https://discord.gg/799cmsYB4q).
+
+**lockc's** userspace part is licensed under [Apache License, version 2.0](https://github.com/rancher-sandbox/lockc/blob/main/LICENSE).
+
+eBPF programs inside [src/bpf directory](https://github.com/rancher-sandbox/lockc/tree/main/src/bpf)
+are licensed under [GNU General Public License, version 2](https://github.com/rancher-sandbox/lockc/blob/main/src/bpf/LICENSE).

--- a/docs/src/README.md
+++ b/docs/src/README.md
@@ -3,6 +3,16 @@
 **lockc** is open source software for providing MAC (Mandatory Access Control)
 type of security audit for container workloads.
 
+The main reason why **lockc** exists is that **containers do not contain**.
+Containers are not as secure and isolated as VMs. By default, they expose
+a lot of information about host OS and provide ways to "break out" from the
+container. **lockc** aims to provide more isolation to containers and make them
+more secure.
+
+The [Containers do not contain](containers-do-not-cointain.md) documentation
+section explains why we mean by that phrase and what kind of behavior we want
+to restrict with **lockc**.
+
 The main technology behind lockc is [eBPF](https://ebpf.io/) - to be more
 precise, its ability to attach to [LSM hooks](https://www.kernel.org/doc/html/latest/bpf/bpf_lsm.html)
 
@@ -16,10 +26,18 @@ to use it is to use the source code and follow the guide.
 If you need help or want to talk with contributors, please come chat with
 us on `#lockc` channel on the [Rust Cloud Native Discord server](https://discord.gg/799cmsYB4q).
 
-You can find the source code on [GitHub](https://github.com/rancher-sandbox/lockc) and issues and feature requests can be posted on the [GitHub issue tracker](https://github.com/rancher-sandbox/lockc/issues). **lockc** relies on the community to fix bugs and
-add features: if you'd like to contribute, please read the [CONTRIBUTING](https://github.com/rancher-sandbox/lockc/blob/master/CONTRIBUTING.md) guide and consider opening [pull request](https://github.com/rancher-sandbox/lockc/pulls).
+You can find the source code on [GitHub](https://github.com/rancher-sandbox/lockc)
+and issues and feature requests can be posted on the
+[GitHub issue tracker](https://github.com/rancher-sandbox/lockc/issues).
+**lockc** relies on the community to fix bugs and add features: if you'd like
+to contribute, please read the [CONTRIBUTING](https://github.com/rancher-sandbox/lockc/blob/master/CONTRIBUTING.md)
+guide and consider opening [pull request](https://github.com/rancher-sandbox/lockc/pulls).
 
 ## License
 
-The lockc source and documentation are released under the [Mozilla Public License v2.0](https://www.mozilla.org/MPL/2.0/).
+**lockc's** userspace part is licensed under [Apache License, version 2.0](https://github.com/rancher-sandbox/lockc/blob/main/LICENSE).
 
+eBPF programs inside [src/bpf directory](https://github.com/rancher-sandbox/lockc/tree/main/src/bpf)
+are licensed under [GNU General Public License, version 2](https://github.com/rancher-sandbox/lockc/blob/main/src/bpf/LICENSE).
+
+Documentation is licensed under [Mozilla Public License v2.0](https://www.mozilla.org/MPL/2.0/).

--- a/docs/src/containers-do-not-contain.md
+++ b/docs/src/containers-do-not-contain.md
@@ -1,0 +1,142 @@
+# Containers to not contain
+
+Many people assume that containers:
+
+- provide the same or similar isolation to virtual machines
+- protects the host system
+- sandboxes applications
+
+While all the points except the first one are partially true, some parts of the
+host filesystems are still exposed by default to containers and there are ways to
+gain full access.
+
+This section highlights and explains problematic exploitation possibilities
+that **lockc** aims to fix via policies.
+
+Please note that as **lockc** is still in early development stage, it doesn't
+protect against all examples provided at this time. However, covering them all
+is in the roadmap.
+
+The goal of **lockc** is to eventually prevent any of those examples to be done
+by a regular user. Following some examples as root by explicitly choosing the
+*privileged* policy level in lockc is going to be still allowed. However, it is
+is discouraged to use the *priviliged* level for containers which are not part
+of Kubernetes infra (CNI plugins, operators, network meshes etc.). We might
+still consider restricting some of behaviors even for *privileged* (i.e. it's
+probably hard to justify `chroot` inside containers under any ciricumstance).
+
+## Not everything is namespaced
+
+Despite the fact that containers come with their own rootfs, some parts of the
+filesystem are **not namespaced**, which means that the content of some
+directories is **exactly the same as on the host OS**. Examples:
+
+- Kernel filesystems under */sys*
+- */proc/bus*
+- */proc/irq*
+- */proc/sys*
+- */proc/sysrq-trigger*
+
+For non-privileged containers, the content of those directories is read-only.
+However, privileged containers can write to them. In both cases, we think that
+even exposing many of those directories without write access is unnecessary
+for regular containers.
+
+To show some more concrete examples, access to those directories can allow to:
+
+- Check and change GPU settings
+
+```bash
+❯ docker run --rm -it opensuse/tumbleweed:latest bash
+f4891490a2f3:/ # cat /sys/class/drm/card0/device/power_dpm_force_performance_level
+auto
+f4891490a2f3:/ # exit
+❯ docker run --rm --privileged -it opensuse/tumbleweed:latest bash
+bad479286479:/ # echo high > /sys/class/drm/card0/device/power_dpm_force_performance_level
+bad479286479:/ # cat /sys/class/drm/card0/device/power_dpm_force_performance_level
+high
+bad479286479:/ # exit
+❯ cat /sys/class/drm/card0/device/power_dpm_force_performance_level
+high
+```
+
+- look at the host OS filesystem metadata
+
+```bash
+❯ docker run --rm -it opensuse/tumbleweed:latest bash
+0d35122d08f9:~ # ls /sys/fs/btrfs/a8222a26-d11e-4276-9c38-9df2812cead2/
+allocation  bdi  bg_reclaim_threshold  checksum  clone_alignment  devices  devinfo  exclusive_operation  features  generation  label  metadata_uuid  nodesize  qgroups  quota_override  read_policy  sectorsize
+```
+
+- use fdisk in a privileged container
+
+```bash
+❯ docker run --rm -it --privileged registry.opensuse.org/opensuse/toolbox:latest bash
+8b71e0119552:/ # fdisk -l
+Disk /dev/nvme0n1: 1.82 TiB, 2000398934016 bytes, 3907029168 sectors
+Disk model: Samsung SSD 970 EVO Plus 2TB
+Units: sectors of 1 * 512 = 512 bytes
+Sector size (logical/physical): 512 bytes / 512 bytes
+I/O size (minimum/optimal): 512 bytes / 512 bytes
+Disklabel type: gpt
+Disk identifier: 8EEBDAB8-F965-4BA0-918A-2671BC67117C
+
+Device           Start        End    Sectors  Size Type
+/dev/nvme0n1p1    2048    1026047    1024000  500M EFI System
+/dev/nvme0n1p2 1026048 3907029134 3906003087  1.8T Linux filesystem
+```
+
+## Host mounts
+
+Container engines allow to bind mount any directory from the host. When using
+local, non-clusterized container engines (docker, podman etc.) there are no
+restrictions about what can be mounted. In case of Docker, anyone who has an
+access to the socket (usually a member of `docker` group) can mount anything.
+
+That gives every member of the `docker` group an access to the host OS as root:
+
+```bash
+❯ docker run --rm --privileged -it -v /:/rootfs opensuse/tumbleweed:latest bash
+efa4f6e0529a:/ # chroot /rootfs
+sh-4.4#
+```
+
+The `chroot` works without `--privileged` as well:
+
+```bash
+❯ docker run --rm -it -v /:/rootfs opensuse/tumbleweed:latest bash
+abb67212044d:/ # chroot /rootfs
+sh-4.4#
+```
+
+The other approach is to mount a Docker socket. The image used here is `docker`
+which is the official image with Docker binaries installed. After starting the
+first container, we are able to list containers running on the host. Then, we
+are able to run another container - from inside the first one - which is
+mounting directories from the host
+
+```bash
+❯ docker run --rm -it -v /var/run/docker.sock:/var/run/docker.sock docker sh
+/ # docker ps
+CONTAINER ID   IMAGE     COMMAND                  CREATED         STATUS         PORTS     NAMES
+066811b60d69   docker    "docker-entrypoint.s…"   5 seconds ago   Up 5 seconds             suspicious_liskov
+/ # docker run --rm --privileged -it opensuse/tumbleweed:latest bash
+fcb94c1d3af6:/ # exit
+/ # docker run --rm --privileged -it -v /:/rootfs opensuse/tumbleweed:latest bash
+54b08e30fd9e:/ # chroot /rootfs
+sh-4.4# cat /etc/os-release
+NAME="openSUSE Leap"
+VERSION="15.3"
+ID="opensuse-leap"
+ID_LIKE="suse opensuse"
+VERSION_ID="15.3"
+PRETTY_NAME="openSUSE Leap 15.3"
+ANSI_COLOR="0;32"
+CPE_NAME="cpe:/o:opensuse:leap:15.3"
+BUG_REPORT_URL="https://bugs.opensuse.org"
+HOME_URL="https://www.opensuse.org/"
+```
+
+Notice the difference between Linux distibution versions. The second container
+image we used is *openSUSE Tumbleweed*, but the host is running
+*openSUSE Leap 15.3*.


### PR DESCRIPTION
That section explains our concerns about container security and shows
examples of potentially malicious activity which we would like to
restrict with lockc.

Signed-off-by: Michal Rostecki <mrostecki@opensuse.org>