### PR TITLE
docs: Fix links to the "Containers do not contain" section

### DIFF
--- a/docs/src/README.md
+++ b/docs/src/README.md
@@ -9,7 +9,7 @@ a lot of information about host OS and provide ways to "break out" from the
 container. **lockc** aims to provide more isolation to containers and make them
 more secure.
 
-The [Containers do not contain](containers-do-not-cointain.md) documentation
+The [Containers do not contain](containers-do-not-contain.md) documentation
 section explains why we mean by that phrase and what kind of behavior we want
 to restrict with **lockc**.
 

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -1,6 +1,7 @@
 # Summary
 
 - [Introduction](README.md)
+- [Containers do not contain](containers-do-not-contain.md)
 - [Architecture](architecture.md)
 - [Getting started](configuration.md)
     - [Build](build/README.md)


### PR DESCRIPTION
Signed-off-by: Michal Rostecki <mrostecki@opensuse.org>