### PR TITLE
terraform: libvirt: Return the whole address list in output

### DIFF
--- a/contrib/terraform/libvirt/output.tf
+++ b/contrib/terraform/libvirt/output.tf
@@ -1,6 +1,6 @@
 output "ip_control_planes" {
   value = zipmap(
     libvirt_domain.control_plane.*.network_interface.0.hostname,
-    libvirt_domain.control_plane.*.network_interface.0.addresses.0,
+    libvirt_domain.control_plane.*.network_interface.0.addresses,
   )
 }


### PR DESCRIPTION
Returning the first element explicitly causes errors of `terraform
destroy` when the network is down and hence the IP address is unknown.
To avoid that issue, let's return the whole list.

Users are (most likely) never going to see an empty list, since the
network should be up after successful run of `terraform apply`.

Also, returning the full list might come handy when we would like to use
IPv6 as well.

Signed-off-by: Michal Rostecki <mrostecki@opensuse.org>