### PR TITLE
build: Handle bpftool command error

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -38,4 +38,6 @@ ENV DAPPER_SOURCE /source
 ENV DAPPER_OUTPUT target
 ENV DAPPER_RUN_ARGS --privileged -v /sys/fs/bpf:/sys/fs/bpf
 
+ENV CLANG /usr/bin/clang-12
+
 WORKDIR ${DAPPER_SOURCE}


### PR DESCRIPTION
Before this change, we switched to downloading vmlinux.h from Github
only on unsuccessful command support. But we didn't handle the error while
creating the output object. This change fixes that.

Signed-off-by: Michal Rostecki <mrostecki@opensuse.org>