### PR TITLE
bpf: Hide directories from access

### DIFF
--- a/contrib/etc/lockc/lockc.toml
+++ b/contrib/etc/lockc/lockc.toml
@@ -5,39 +5,100 @@ runtimes = ["runc"]
 # filesystem in containers with "restricted" policy.
 # By default, these are only directories used by container runtimes (i.e. runc),
 # engines (i.e. containerd, cri-o, podman) and kubelet.
-allowed_paths_rescricted = [
+allowed_paths_mount_restricted = [
+    # Path to Pseudo-Terminal Device, needed for -it option in container runtimes.
     "/dev/pts",
+    # Storage directory used by libpod (podman, cri-o).
     "/var/lib/containers/storage",
+    # Storage directory used by docker (overlay2 driver).
+    "/var/lib/docker/overlay2",
+    # Storage directory used by containerd.
     "/var/run/container",
+    # Storage directory used by CRI containerd.
     "/run/containerd/io.containerd.runtime.v1.linux",
+    # Data directory used by docker.
+    "/var/lib/docker/containers",
+    # Sandbox directory used by containerd.
     "/run/containerd/io.containerd.grpc.v1.cri/sandboxes",
+    # Sandbox directory used by containerd.
     "/var/lib/containerd/io.containerd.grpc.v1.cri/sandboxes",
+    # Misc cgroup controller.
     "/sys/fs/cgroup/misc",
+    # RDMA controller.
     "/sys/fs/cgroup/rdma",
+    # Block I/O controller for libpod (podman, cri-o).
     "/sys/fs/cgroup/blkio/machine.slice",
+    # CPU accounting controller for libpod (podman, cri-o).
     "/sys/fs/cgroup/cpu,cpuacct/machine.slice",
+    # Cpusets for libpod (podman, cri-o).
     "/sys/fs/cgroup/cpuset/machine.slice",
+    # Device allowlist controller for libpod (podman, cri-o).
     "/sys/fs/cgroup/devices/machine.slice",
+    # Cgroup freezer for libpod (podman, cri-o).
     "/sys/fs/cgroup/freezer/machine.slice",
+    # HugeTLB controller for libpod (podman, cri-o).
     "/sys/fs/cgroup/hugetlb/machine.slice",
+    # Memory controller for libpod (podman, cri-o).
     "/sys/fs/cgroup/memory/machine.slice",
+    # Network classifier and priority controller for libpod (podman, cri-o).
     "/sys/fs/cgroup/net_cls,net_prio/machine.slice",
+    # Perf event controller for libpod (podman, cri-o).
     "/sys/fs/cgroup/perf_event/machine.slice",
+    # Process number controller for libpod (podman, cri-o).
     "/sys/fs/cgroup/pids/machine.slice",
+    # Cgroup v1 hierarchy (used by systemd) for libpod (podman, cri-o).
     "/sys/fs/cgroup/systemd/machine.slice",
+    # Cgroup v2 hierarchy (used by systemd) for libpod (podman, cri-o).
     "/sys/fs/cgroup/unified/machine.slice",
+    # Block I/O controller for kubelet.
     "/sys/fs/cgroup/blkio/kubepods.slice",
+    # CPU accounting controller for kubelet.
     "/sys/fs/cgroup/cpu,cpuacct/kubepods.slice",
+    # Cpusets for libpod for kubelet.
     "/sys/fs/cgroup/cpuset/kubepods.slice",
+    # Device allowlist controller for kubelet.
     "/sys/fs/cgroup/devices/kubepods.slice",
+    # Cgroup freezer for kubelet.
     "/sys/fs/cgroup/freezer/kubepods.slice",
+    # HugeTLB controller for kubelet.
     "/sys/fs/cgroup/hugetlb/kubepods.slice",
+    # Memory controller for kubelet.
     "/sys/fs/cgroup/memory/kubepods.slice",
+    # Network classifier and priority controller for kubelet.
     "/sys/fs/cgroup/net_cls,net_prio/kubepods.slice",
+    # Perf event controller for kubelet.
     "/sys/fs/cgroup/perf_event/kubepods.slice",
+    # Process number controller for kubelet.
     "/sys/fs/cgroup/pids/kubepods.slice",
+    # Cgroup v1 hierarchy (used by systemd) for kubelet.
     "/sys/fs/cgroup/systemd/kubepods.slice",
+    # Cgroup v2 hierarchy (used by systemd) for kubelet.
     "/sys/fs/cgroup/unified/kubepods.slice",
+    # Block I/O controller for docker.
+    "/sys/fs/cgroup/blkio/docker",
+    # CPU accounting controller for docker.
+    "/sys/fs/cgroup/cpu,cpuacct/docker",
+    # Cpusets for docker.
+    "/sys/fs/cgroup/cpuset/docker",
+    # Device allowlist controller for docker.
+    "/sys/fs/cgroup/devices/docker",
+    # Cgroup freezer for docker.
+    "/sys/fs/cgroup/freezer/docker",
+    # HugeTLB controller for docker.
+    "/sys/fs/cgroup/hugetlb/docker",
+    # Memory controller for docker.
+    "/sys/fs/cgroup/memory/docker",
+    # Network classifier and priority controller for docker.
+    "/sys/fs/cgroup/net_cls,net_prio/docker",
+    # Perf event controller for docker.
+    "/sys/fs/cgroup/perf_event/docker",
+    # Process number controller for docker.
+    "/sys/fs/cgroup/pids/docker",
+    # Cgroup v1 hierarchy (used by systemd) for docker.
+    "/sys/fs/cgroup/systemd/docker",
+    # Cgroup v2 hierarchy (used by systemd) for docker.
+    "/sys/fs/cgroup/unified/docker",
+    # State and ephemeral storage for kubelet.
     "/var/lib/kubelet/pods",
 ]
 
@@ -47,43 +108,153 @@ allowed_paths_rescricted = [
 # * /home
 # * /var/data
 # * directories used by container runtimes, engines and kubelet
-allowed_paths_baseline = [
+allowed_paths_mount_baseline = [
     # Directories used by container runtimes, engines and kubelet.
+
+    # Path to Pseudo-Terminal Device, needed for -it option in container runtimes.
     "/dev/pts",
+    # Storage directory used by libpod (podman, cri-o).
     "/var/lib/containers/storage",
+    # Storage directory used by docker (overlay2 driver).
+    "/var/lib/docker/overlay2",
+    # Storage directory used by containerd.
     "/var/run/container",
+    # Storage directory used by CRI containerd.
     "/run/containerd/io.containerd.runtime.v1.linux",
+    # Data directory used by docker.
+    "/var/lib/docker/containers",
+    # Sandbox directory used by containerd.
     "/run/containerd/io.containerd.grpc.v1.cri/sandboxes",
+    # Sandbox directory used by containerd.
     "/var/lib/containerd/io.containerd.grpc.v1.cri/sandboxes",
+    # Misc cgroup controller.
     "/sys/fs/cgroup/misc",
+    # RDMA controller.
     "/sys/fs/cgroup/rdma",
+    # Block I/O controller for libpod (podman, cri-o).
     "/sys/fs/cgroup/blkio/machine.slice",
+    # CPU accounting controller for libpod (podman, cri-o).
     "/sys/fs/cgroup/cpu,cpuacct/machine.slice",
+    # Cpusets for libpod (podman, cri-o).
     "/sys/fs/cgroup/cpuset/machine.slice",
+    # Device allowlist controller for libpod (podman, cri-o).
     "/sys/fs/cgroup/devices/machine.slice",
+    # Cgroup freezer for libpod (podman, cri-o).
     "/sys/fs/cgroup/freezer/machine.slice",
+    # HugeTLB controller for libpod (podman, cri-o).
     "/sys/fs/cgroup/hugetlb/machine.slice",
+    # Memory controller for libpod (podman, cri-o).
     "/sys/fs/cgroup/memory/machine.slice",
+    # Network classifier and priority controller for libpod (podman, cri-o).
     "/sys/fs/cgroup/net_cls,net_prio/machine.slice",
+    # Perf event controller for libpod (podman, cri-o).
     "/sys/fs/cgroup/perf_event/machine.slice",
+    # Process number controller for libpod (podman, cri-o).
     "/sys/fs/cgroup/pids/machine.slice",
+    # Cgroup v1 hierarchy (used by systemd) for libpod (podman, cri-o).
     "/sys/fs/cgroup/systemd/machine.slice",
+    # Cgroup v2 hierarchy (used by systemd) for libpod (podman, cri-o).
     "/sys/fs/cgroup/unified/machine.slice",
+    # Block I/O controller for kubelet.
     "/sys/fs/cgroup/blkio/kubepods.slice",
+    # CPU accounting controller for kubelet.
     "/sys/fs/cgroup/cpu,cpuacct/kubepods.slice",
+    # Cpusets for libpod for kubelet.
     "/sys/fs/cgroup/cpuset/kubepods.slice",
+    # Device allowlist controller for kubelet.
     "/sys/fs/cgroup/devices/kubepods.slice",
+    # Cgroup freezer for kubelet.
     "/sys/fs/cgroup/freezer/kubepods.slice",
+    # HugeTLB controller for kubelet.
     "/sys/fs/cgroup/hugetlb/kubepods.slice",
+    # Memory controller for kubelet.
     "/sys/fs/cgroup/memory/kubepods.slice",
+    # Network classifier and priority controller for kubelet.
     "/sys/fs/cgroup/net_cls,net_prio/kubepods.slice",
+    # Perf event controller for kubelet.
     "/sys/fs/cgroup/perf_event/kubepods.slice",
+    # Process number controller for kubelet.
     "/sys/fs/cgroup/pids/kubepods.slice",
+    # Cgroup v1 hierarchy (used by systemd) for kubelet.
     "/sys/fs/cgroup/systemd/kubepods.slice",
+    # Cgroup v2 hierarchy (used by systemd) for kubelet.
     "/sys/fs/cgroup/unified/kubepods.slice",
+    # Block I/O controller for docker.
+    "/sys/fs/cgroup/blkio/docker",
+    # CPU accounting controller for docker.
+    "/sys/fs/cgroup/cpu,cpuacct/docker",
+    # Cpusets for docker.
+    "/sys/fs/cgroup/cpuset/docker",
+    # Device allowlist controller for docker.
+    "/sys/fs/cgroup/devices/docker",
+    # Cgroup freezer for docker.
+    "/sys/fs/cgroup/freezer/docker",
+    # HugeTLB controller for docker.
+    "/sys/fs/cgroup/hugetlb/docker",
+    # Memory controller for docker.
+    "/sys/fs/cgroup/memory/docker",
+    # Network classifier and priority controller for docker.
+    "/sys/fs/cgroup/net_cls,net_prio/docker",
+    # Perf event controller for docker.
+    "/sys/fs/cgroup/perf_event/docker",
+    # Process number controller for docker.
+    "/sys/fs/cgroup/pids/docker",
+    # Cgroup v1 hierarchy (used by systemd) for docker.
+    "/sys/fs/cgroup/systemd/docker",
+    # Cgroup v2 hierarchy (used by systemd) for docker.
+    "/sys/fs/cgroup/unified/docker",
+    # State and ephemeral storage for kubelet.
     "/var/lib/kubelet/pods",
 
     # Directories mounted by container engine user.
+
     "/home",
     "/var/data",
+]
+
+allowed_paths_access_restricted = [
+    "/bin",
+    "/dev/console",
+    "/dev/full",
+    "/dev/null",
+    "/dev/pts",
+    "/dev/tty",
+    "/dev/urandom",
+    "/dev/zero",
+    "/etc",
+    "/home",
+    "/lib",
+    "/proc",
+    "/sys/fs/cgroup",
+    "/tmp",
+    "/usr",
+    "/var",
+]
+
+allowed_paths_access_baseline = [
+    "/bin",
+    "/dev/console",
+    "/dev/full",
+    "/dev/null",
+    "/dev/pts",
+    "/dev/tty",
+    "/dev/urandom",
+    "/dev/zero",
+    "/etc",
+    "/home",
+    "/lib",
+    "/proc",
+    "/sys/fs/cgroup",
+    "/tmp",
+    "/usr",
+    "/var",
+]
+
+denied_paths_access_restricted = [
+    "/proc/acpi",
+]
+
+denied_paths_access_baseline = [
+    "/proc/acpi",
+    "/proc/sys",
 ]

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -14,6 +14,7 @@
         - [Use libvirt](terraform/libvirt.md)
         - [Use OpenStack](terraform/openstack.md)
 - [Policies](policies/README.md)
+    - [File access](policies/file-access.md)
     - [Mount](policies/mount.md)
     - [Syslog](policies/syslog.md)
 - [Demos](demos/README.md)

--- a/docs/src/policies/file-access.md
+++ b/docs/src/policies/file-access.md
@@ -1,0 +1,62 @@
+## File access
+
+lockc comes with policies about file access which is based on allow- and
+deny-listing. **Baseline** and **restricted** policies have their own pairs of
+lists. All those lists should contain path prefixes. All the children of listed
+paths/directories are included, since the decision is made by prefix matching.
+
+The deny list has precedence over allow list. That's because main purpose of
+the deny list is specifying exceptions whose prefixes are specified in the
+allow list, but we don't want to allow them.
+
+To sum it up, when any process in the container tries to access a file, lockc:
+
+1. Checks whether the given path's prefix is in the deny list. If yes, denies
+   the access.
+2. Checks whether the given path's prefix is in the allow list. If yes, allows
+   the access.
+3. In case of no matches, denies the access.
+
+By default, the contents of lists are:
+
+* **baseline**
+  * allow list
+    * */bin*
+    * */dev/console*
+    * */dev/full*
+    * */dev/null*
+    * */dev/pts*
+    * */dev/tty*
+    * */dev/urandom*
+    * */dev/zero*
+    * */etc*
+    * */home*
+    * */lib*
+    * */proc*
+    * */sys/fs/cgroup*
+    * */tmp*
+    * */usr*
+    * */var*
+  * deny list
+    * */proc/acpi*
+* **restricted**
+  * allow list
+    * */bin*
+    * */dev/console*
+    * */dev/full*
+    * */dev/null*
+    * */dev/pts*
+    * */dev/tty*
+    * */dev/urandom*
+    * */dev/zero*
+    * */etc*
+    * */home*
+    * */lib*
+    * */proc*
+    * */sys/fs/cgroup*
+    * */tmp*
+    * */usr*
+    * */var*
+  * deny list
+    * */proc/acpi*
+    * */proc/sys*

--- a/lockc/src/bpf/map_structs.h
+++ b/lockc/src/bpf/map_structs.h
@@ -12,6 +12,6 @@ struct process {
 	unsigned int container_id;
 };
 
-struct allowed_path {
+struct accessed_path {
 	unsigned char path[PATH_LEN];
 };

--- a/lockc/src/bpf/maps.h
+++ b/lockc/src/bpf/maps.h
@@ -39,27 +39,75 @@ struct {
 } processes SEC(".maps");
 
 /*
- * allowed_paths_restricted - BPF map which contains the source path prefixes
- * allowed to bind mount from host to restricted containers. It should contain
- * only paths used by default by container runtimes, not paths mounted with the
- * -v option.
+ * allowed_paths_mount_restricted - BPF map which contains the source path
+ * prefixes allowed to bind mount from host to restricted containers. It should
+ * contain only paths used by default by container runtimes, not paths mounted
+ * with the -v option.
  */
 struct {
 	__uint(type, BPF_MAP_TYPE_HASH);
 	__uint(max_entries, PATH_MAX_LIMIT);
 	__type(key, u32);
-	__type(value, struct allowed_path);
-} allowed_paths_restricted SEC(".maps");
+	__type(value, struct accessed_path);
+} allowed_paths_mount_restricted SEC(".maps");
 
 /*
- * allowed_paths_baseline - BPF map which contains the source path prefixes
- * allowed to bind mount from host to baseline containers. It should contain
- * both paths used by default by container runtimes and paths we allow to mount
- * with -v option.
+ * allowed_paths_mount_baseline - BPF map which contains the source path
+ * prefixes allowed to bind mount from host to baseline containers. It
+ * should contain both paths used by default by container runtimes and
+ * paths we allow to mount with -v option.
  */
 struct {
 	__uint(type, BPF_MAP_TYPE_HASH);
 	__uint(max_entries, PATH_MAX_LIMIT);
 	__type(key, u32);
-	__type(value, struct allowed_path);
-} allowed_paths_baseline SEC(".maps");
+	__type(value, struct accessed_path);
+} allowed_paths_mount_baseline SEC(".maps");
+
+/*
+ * allowed_paths_access_restricted - BPF map which contains the path prefixes
+ * allowed to access (open, create, delete, move etc.) inside filesystems of
+ * restricted containers.
+ */
+struct {
+	__uint(type, BPF_MAP_TYPE_HASH);
+	__uint(max_entries, PATH_MAX_LIMIT);
+	__type(key, u32);
+	__type(value, struct accessed_path);
+} allowed_paths_access_restricted SEC(".maps");
+
+/*
+ * allowed_paths_access_baseline - BPF map which contains the path prefixes
+ * allowed to access (open, create, delete, move etc.) inside filesystems of
+ * baseline containers.
+ */
+struct {
+	__uint(type, BPF_MAP_TYPE_HASH);
+	__uint(max_entries, PATH_MAX_LIMIT);
+	__type(key, u32);
+	__type(value, struct accessed_path);
+} allowed_paths_access_baseline SEC(".maps");
+
+/*
+ * denied_paths_access_restricted - BPF map which contains the path prefixes
+ * denied to access (open, create, delete, move etc.) inside filesystems of
+ * restricted containers.
+ */
+struct {
+	__uint(type, BPF_MAP_TYPE_HASH);
+	__uint(max_entries, PATH_MAX_LIMIT);
+	__type(key, u32);
+	__type(value, struct accessed_path);
+} denied_paths_access_restricted SEC(".maps");
+
+/*
+ * denied_paths_access_baseline - BPF map which contains the path prefixes
+ * denied to access (open, create, delete, move etc.) inside filesystems of
+ * baseline containers.
+ */
+struct {
+	__uint(type, BPF_MAP_TYPE_HASH);
+	__uint(max_entries, PATH_MAX_LIMIT);
+	__type(key, u32);
+	__type(value, struct accessed_path);
+} denied_paths_access_baseline SEC(".maps");

--- a/lockc/src/bpfstructs.rs
+++ b/lockc/src/bpfstructs.rs
@@ -51,15 +51,15 @@ pub trait BpfStruct {
 
 impl BpfStruct for container {}
 impl BpfStruct for process {}
-impl BpfStruct for allowed_path {}
+impl BpfStruct for accessed_path {}
 
-impl allowed_path {
-    /// Creates a new allowed_path instance and converts the given Rust string
+impl accessed_path {
+    /// Creates a new accessed_path instance and converts the given Rust string
     /// into C fixed-size char array.
     pub fn new(path: &str) -> Result<Self, NewBpfstructError> {
         let mut path_b = std::ffi::CString::new(path)?.into_bytes_with_nul();
         path_b.resize(PATH_LEN as usize, 0);
-        Ok(allowed_path {
+        Ok(accessed_path {
             path: path_b.try_into().unwrap(),
         })
     }
@@ -70,20 +70,20 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_allowed_path_new() {
-        let ap1 = allowed_path::new("/foo/bar").unwrap();
+    fn test_accessed_path_new() {
+        let ap1 = accessed_path::new("/foo/bar").unwrap();
         assert_eq!(
             &ap1.path,
             b"/foo/bar\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0"
         );
 
-        let ap2 = allowed_path::new("/ayy/lmao").unwrap();
+        let ap2 = accessed_path::new("/ayy/lmao").unwrap();
         assert_eq!(
             &ap2.path,
             b"/ayy/lmao\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0"
         );
 
-        let ap3 = allowed_path::new(
+        let ap3 = accessed_path::new(
             "/this/is/gonna/be/a/veeeeeeeeery/looooooooooooooooong/paaaaaaaaaaaaaaaaaaaath",
         )
         .unwrap();

--- a/lockc/src/settings.rs
+++ b/lockc/src/settings.rs
@@ -6,50 +6,129 @@ use crate::bpfstructs;
 /// runtimes.
 static DIR_PTS: &str = "/dev/pts";
 
-// Storage
+// Storage directories
 
-/// Path to image layers used by libpod (podman, cri-o).
+/// Storage directory used by libpod (podman, cri-o).
 static DIR_STORAGE_LIBPOD: &str = "/var/lib/containers/storage";
-/// Path to image layers used by containerd.
+/// Storage directory used by docker (overlay2 driver).
+static DIR_STORAGE_DOCKER_OVERLAY2: &str = "/var/lib/docker/overlay2";
+/// Storage directory used by containerd.
 static DIR_STORAGE_CONTAINERD: &str = "/var/run/container";
+/// Storage directory used by CRI containerd.
 static DIR_STORAGE_CRI_CONTAINERD: &str = "/run/containerd/io.containerd.runtime.v1.linux";
+
+/// Data directory used by docker.
+static DIR_DATA_DOCKER: &str = "/var/lib/docker/containers";
+
+/// Sandbox directory used by containerd.
 static DIR_SANDBOXES_CRI_CONTAINERD1: &str = "/run/containerd/io.containerd.grpc.v1.cri/sandboxes";
+/// Sandbox directory used by containerd.
 static DIR_SANDBOXES_CRI_CONTAINERD2: &str =
     "/var/lib/containerd/io.containerd.grpc.v1.cri/sandboxes";
 
-// cgroups
+// Cgroup directories
 
+/// Misc cgroup controller.
 static DIR_CGROUP_MISC: &str = "/sys/fs/cgroup/misc";
+/// RDMA controller.
 static DIR_CGROUP_RDMA: &str = "/sys/fs/cgroup/rdma";
+/// Block I/O controller for libpod (podman, cri-o).
 static DIR_CGROUP_BLKIO_LIBPOD: &str = "/sys/fs/cgroup/blkio/machine.slice";
+/// CPU accounting controller for libpod (podman, cri-o).
 static DIR_CGROUP_CPU_LIBPOD: &str = "/sys/fs/cgroup/cpu,cpuacct/machine.slice";
+/// Cpusets for libpod (podman, cri-o).
 static DIR_CGROUP_CPUSET_LIBPOD: &str = "/sys/fs/cgroup/cpuset/machine.slice";
+/// Device allowlist controller for libpod (podman, cri-o).
 static DIR_CGROUP_DEVICES_LIBPOD: &str = "/sys/fs/cgroup/devices/machine.slice";
+/// Cgroup freezer for libpod (podman, cri-o).
 static DIR_CGROUP_FREEZER_LIBPOD: &str = "/sys/fs/cgroup/freezer/machine.slice";
+/// HugeTLB controller for libpod (podman, cri-o).
 static DIR_CGROUP_HUGETLB_LIBPOD: &str = "/sys/fs/cgroup/hugetlb/machine.slice";
+/// Memory controller for libpod (podman, cri-o).
 static DIR_CGROUP_MEMORY_LIBPOD: &str = "/sys/fs/cgroup/memory/machine.slice";
+/// Network classifier and priority controller for libpod (podman, cri-o).
 static DIR_CGROUP_NET_LIBPOD: &str = "/sys/fs/cgroup/net_cls,net_prio/machine.slice";
+/// Perf event controller for libpod (podman, cri-o).
 static DIR_CGROUP_PERF_LIBPOD: &str = "/sys/fs/cgroup/perf_event/machine.slice";
+/// Process number controller for libpod (podman, cri-o).
 static DIR_CGROUP_PIDS_LIBPOD: &str = "/sys/fs/cgroup/pids/machine.slice";
+/// Cgroup v1 hierarchy (used by systemd) for libpod (podman, cri-o).
 static DIR_CGROUP_SYSTEMD_LIBPOD: &str = "/sys/fs/cgroup/systemd/machine.slice";
+/// Cgroup v2 hierarchy (used by systemd) for libpod (podman, cri-o).
 static DIR_CGROUP_UNIFIED_LIBPOD: &str = "/sys/fs/cgroup/unified/machine.slice";
+/// Block I/O controller for kubelet.
 static DIR_CGROUP_BLKIO_K8S: &str = "/sys/fs/cgroup/blkio/kubepods.slice";
+/// CPU accounting controller for kubelet.
 static DIR_CGROUP_CPU_K8S: &str = "/sys/fs/cgroup/cpu,cpuacct/kubepods.slice";
+/// Cpusets for libpod for kubelet.
 static DIR_CGROUP_CPUSET_K8S: &str = "/sys/fs/cgroup/cpuset/kubepods.slice";
+/// Device allowlist controller for kubelet.
 static DIR_CGROUP_DEVICES_K8S: &str = "/sys/fs/cgroup/devices/kubepods.slice";
+/// Cgroup freezer for kubelet.
 static DIR_CGROUP_FREEZER_K8S: &str = "/sys/fs/cgroup/freezer/kubepods.slice";
+/// HugeTLB controller for kubelet.
 static DIR_CGROUP_HUGETLB_K8S: &str = "/sys/fs/cgroup/hugetlb/kubepods.slice";
+/// Memory controller for kubelet.
 static DIR_CGROUP_MEMORY_K8S: &str = "/sys/fs/cgroup/memory/kubepods.slice";
+/// Network classifier and priority controller for kubelet.
 static DIR_CGROUP_NET_K8S: &str = "/sys/fs/cgroup/net_cls,net_prio/kubepods.slice";
+/// Perf event controller for kubelet.
 static DIR_CGROUP_PERF_K8S: &str = "/sys/fs/cgroup/perf_event/kubepods.slice";
+/// Process number controller for kubelet.
 static DIR_CGROUP_PIDS_K8S: &str = "/sys/fs/cgroup/pids/kubepods.slice";
+/// Cgroup v1 hierarchy (used by systemd) for kubelet.
 static DIR_CGROUP_SYSTEMD_K8S: &str = "/sys/fs/cgroup/systemd/kubepods.slice";
+/// Cgroup v2 hierarchy (used by systemd) for kubelet.
 static DIR_CGROUP_UNIFIED_K8S: &str = "/sys/fs/cgroup/unified/kubepods.slice";
+/// Block I/O controller for docker.
+static DIR_CGROUP_BLKIO_DOCKER: &str = "/sys/fs/cgroup/blkio/docker";
+/// CPU accounting controller for docker.
+static DIR_CGROUP_CPU_DOCKER: &str = "/sys/fs/cgroup/cpu,cpuacct/docker";
+/// Cpusets for docker.
+static DIR_CGROUP_CPUSET_DOCKER: &str = "/sys/fs/cgroup/cpuset/docker";
+/// Device allowlist controller for docker.
+static DIR_CGROUP_DEVICES_DOCKER: &str = "/sys/fs/cgroup/devices/docker";
+/// Cgroup freezer for docker.
+static DIR_CGROUP_FREEZER_DOCKER: &str = "/sys/fs/cgroup/freezer/docker";
+/// HugeTLB controller for docker.
+static DIR_CGROUP_HUGETLB_DOCKER: &str = "/sys/fs/cgroup/hugetlb/docker";
+/// Memory controller for docker.
+static DIR_CGROUP_MEMORY_DOCKER: &str = "/sys/fs/cgroup/memory/docker";
+/// Network classifier and priority controller for docker.
+static DIR_CGROUP_NET_DOCKER: &str = "/sys/fs/cgroup/net_cls,net_prio/docker";
+/// Perf event controller for docker.
+static DIR_CGROUP_PERF_DOCKER: &str = "/sys/fs/cgroup/perf_event/docker";
+/// Process number controller for docker.
+static DIR_CGROUP_PIDS_DOCKER: &str = "/sys/fs/cgroup/pids/docker";
+/// Cgroup v1 hierarchy (used by systemd) for docker.
+static DIR_CGROUP_SYSTEMD_DOCKER: &str = "/sys/fs/cgroup/systemd/docker";
+/// Cgroup v2 hierarchy (used by systemd) for docker.
+static DIR_CGROUP_UNIFIED_DOCKER: &str = "/sys/fs/cgroup/unified/docker";
 
+/// State and ephemeral storage for kubelet.
 static DIR_PODS_KUBELET: &str = "/var/lib/kubelet/pods";
 
 static DIR_HOME: &str = "/home";
 static DIR_VAR_DATA: &str = "/var/data";
+
+static DIR_BIN: &str = "/bin";
+static DIR_DEV_CONSOLE: &str = "/dev/console";
+static DIR_DEV_FULL: &str = "/dev/full";
+static DIR_DEV_NULL: &str = "/dev/null";
+static DIR_DEV_PTS: &str = "/dev/pts";
+static DIR_DEV_TTY: &str = "/dev/tty";
+static DIR_DEV_URANDOM: &str = "/dev/urandom";
+static DIR_DEV_ZERO: &str = "/dev/zero";
+static DIR_ETC: &str = "/etc";
+static DIR_LIB: &str = "/lib";
+static DIR_PROC: &str = "/proc";
+static DIR_CGROUP: &str = "/sys/fs/cgroup";
+static DIR_TMP: &str = "/tmp";
+static DIR_USR: &str = "/usr";
+static DIR_VAR: &str = "/var";
+
+static DIR_PROC_ACPI: &str = "/proc/acpi";
+static DIR_PROC_SYS: &str = "/proc/sys";
 
 #[derive(Debug, serde::Deserialize)]
 pub struct Settings {
@@ -57,11 +136,15 @@ pub struct Settings {
     /// Paths which are allowed in restricted policy. These are only paths
     /// which are used by default by container runtimes, not paths mounted
     /// with the -v option.
-    pub allowed_paths_restricted: Vec<String>,
+    pub allowed_paths_mount_restricted: Vec<String>,
     /// Paths which are allowed in baseline policy. These are both paths
     /// used by default by container runtimes and few directories which we
     /// allow to mount with -v option.
-    pub allowed_paths_baseline: Vec<String>,
+    pub allowed_paths_mount_baseline: Vec<String>,
+    pub allowed_paths_access_restricted: Vec<String>,
+    pub allowed_paths_access_baseline: Vec<String>,
+    pub denied_paths_access_restricted: Vec<String>,
+    pub denied_paths_access_baseline: Vec<String>,
 }
 
 fn trim_task_comm_len(mut s: std::string::String) -> std::string::String {
@@ -89,12 +172,14 @@ impl Settings {
 
         s.set("runtimes", vec![trim_task_comm_len("runc".to_string())])?;
         s.set(
-            "allowed_paths_restricted",
+            "allowed_paths_mount_restricted",
             vec![
                 DIR_PTS.to_string(),
                 DIR_STORAGE_LIBPOD.to_string(),
+                DIR_STORAGE_DOCKER_OVERLAY2.to_string(),
                 DIR_STORAGE_CONTAINERD.to_string(),
                 DIR_STORAGE_CRI_CONTAINERD.to_string(),
+                DIR_DATA_DOCKER.to_string(),
                 DIR_SANDBOXES_CRI_CONTAINERD1.to_string(),
                 DIR_SANDBOXES_CRI_CONTAINERD2.to_string(),
                 DIR_CGROUP_MISC.to_string(),
@@ -123,17 +208,31 @@ impl Settings {
                 DIR_CGROUP_PIDS_K8S.to_string(),
                 DIR_CGROUP_SYSTEMD_K8S.to_string(),
                 DIR_CGROUP_UNIFIED_K8S.to_string(),
+                DIR_CGROUP_BLKIO_DOCKER.to_string(),
+                DIR_CGROUP_CPU_DOCKER.to_string(),
+                DIR_CGROUP_CPUSET_DOCKER.to_string(),
+                DIR_CGROUP_DEVICES_DOCKER.to_string(),
+                DIR_CGROUP_FREEZER_DOCKER.to_string(),
+                DIR_CGROUP_HUGETLB_DOCKER.to_string(),
+                DIR_CGROUP_MEMORY_DOCKER.to_string(),
+                DIR_CGROUP_NET_DOCKER.to_string(),
+                DIR_CGROUP_PERF_DOCKER.to_string(),
+                DIR_CGROUP_PIDS_DOCKER.to_string(),
+                DIR_CGROUP_SYSTEMD_DOCKER.to_string(),
+                DIR_CGROUP_UNIFIED_DOCKER.to_string(),
                 DIR_PODS_KUBELET.to_string(),
             ],
         )?;
         s.set(
-            "allowed_paths_baseline",
+            "allowed_paths_mount_baseline",
             vec![
                 // Paths used by container runtimes.
                 DIR_PTS.to_string(),
                 DIR_STORAGE_LIBPOD.to_string(),
+                DIR_STORAGE_DOCKER_OVERLAY2.to_string(),
                 DIR_STORAGE_CONTAINERD.to_string(),
                 DIR_STORAGE_CRI_CONTAINERD.to_string(),
+                DIR_DATA_DOCKER.to_string(),
                 DIR_SANDBOXES_CRI_CONTAINERD1.to_string(),
                 DIR_SANDBOXES_CRI_CONTAINERD2.to_string(),
                 DIR_CGROUP_MISC.to_string(),
@@ -162,11 +261,73 @@ impl Settings {
                 DIR_CGROUP_PIDS_K8S.to_string(),
                 DIR_CGROUP_SYSTEMD_K8S.to_string(),
                 DIR_CGROUP_UNIFIED_K8S.to_string(),
+                DIR_CGROUP_BLKIO_DOCKER.to_string(),
+                DIR_CGROUP_CPU_DOCKER.to_string(),
+                DIR_CGROUP_CPUSET_DOCKER.to_string(),
+                DIR_CGROUP_DEVICES_DOCKER.to_string(),
+                DIR_CGROUP_FREEZER_DOCKER.to_string(),
+                DIR_CGROUP_HUGETLB_DOCKER.to_string(),
+                DIR_CGROUP_MEMORY_DOCKER.to_string(),
+                DIR_CGROUP_NET_DOCKER.to_string(),
+                DIR_CGROUP_PERF_DOCKER.to_string(),
+                DIR_CGROUP_PIDS_DOCKER.to_string(),
+                DIR_CGROUP_SYSTEMD_DOCKER.to_string(),
+                DIR_CGROUP_UNIFIED_DOCKER.to_string(),
                 DIR_PODS_KUBELET.to_string(),
                 // Paths we allow to mount with -v option.
                 DIR_HOME.to_string(),
                 DIR_VAR_DATA.to_string(),
             ],
+        )?;
+        s.set(
+            "allowed_paths_access_restricted",
+            vec![
+                DIR_BIN.to_string(),
+                DIR_DEV_CONSOLE.to_string(),
+                DIR_DEV_FULL.to_string(),
+                DIR_DEV_NULL.to_string(),
+                DIR_DEV_PTS.to_string(),
+                DIR_DEV_TTY.to_string(),
+                DIR_DEV_URANDOM.to_string(),
+                DIR_DEV_ZERO.to_string(),
+                DIR_ETC.to_string(),
+                DIR_HOME.to_string(),
+                DIR_LIB.to_string(),
+                DIR_PROC.to_string(),
+                DIR_CGROUP.to_string(),
+                DIR_TMP.to_string(),
+                DIR_USR.to_string(),
+                DIR_VAR.to_string(),
+            ],
+        )?;
+        s.set(
+            "allowed_paths_access_baseline",
+            vec![
+                DIR_BIN.to_string(),
+                DIR_DEV_CONSOLE.to_string(),
+                DIR_DEV_FULL.to_string(),
+                DIR_DEV_NULL.to_string(),
+                DIR_DEV_PTS.to_string(),
+                DIR_DEV_TTY.to_string(),
+                DIR_DEV_URANDOM.to_string(),
+                DIR_DEV_ZERO.to_string(),
+                DIR_ETC.to_string(),
+                DIR_HOME.to_string(),
+                DIR_LIB.to_string(),
+                DIR_PROC.to_string(),
+                DIR_CGROUP.to_string(),
+                DIR_TMP.to_string(),
+                DIR_USR.to_string(),
+                DIR_VAR.to_string(),
+            ],
+        )?;
+        s.set(
+            "denied_paths_access_restricted",
+            vec![DIR_PROC_ACPI.to_string()],
+        )?;
+        s.set(
+            "denied_paths_access_baseline",
+            vec![DIR_PROC_ACPI.to_string(), DIR_PROC_SYS.to_string()],
         )?;
 
         s.merge(config::File::with_name("/etc/lockc/lockc.toml").required(false))?;


### PR DESCRIPTION
This change adds new BPF programs which restrict the filesystem access
(open) inside containers based on configurable allow and deny BPF maps.
Allow/deny lists of directories are available in the usespace in lockc
configuration.

It can be tested by trying to access a denied directory in a container,
like:

```
lockc-control-plane-0:~ # docker run --rm -it busybox sh
/ # ls /sys
ls: can't open '/sys': Operation not permitted
/ # ls /home
/ #
```

Fixes: #48
Signed-off-by: Michal Rostecki <mrostecki@opensuse.org>