### PR TITLE
guestfs: Call xtask binary directly inside VM

### DIFF
--- a/contrib/guestfs/install-lockc.sh
+++ b/contrib/guestfs/install-lockc.sh
@@ -5,7 +5,12 @@ set -eux
 pushd /usr/local/src/lockc
 
 if [ -d "target/" ]; then
-    cargo xtask install
+    # Calling xtask binary directly, because doing `cargo xtask ...` on VM has
+    # sometimes weird consequences - sometimes cargo tries to rebuild xtask
+    # (even though it was built on host already) and then linker complains
+    # (obviously because of mismatch between objects which were compiled on the
+    # host and those getting compiled inside VM).
+    ./target/debug/xtask install
 else
     echo "lockc was not build, cannot install" >&2
     exit 1


### PR DESCRIPTION
Doing `cargo xtask ...` on VM has sometimes weird consequences -
sometimes cargo tries to rebuild xtask (even though it was built on host
already) and then linker complains (obviously because of mismatch
between objects which were compiled on the host and those getting
compiled inside VM).

Because of that, call xtask binary directly.

Signed-off-by: Michal Rostecki <mrostecki@opensuse.org>