### PR TITLE
Add 9p drivers to initrd

### DIFF
--- a/contrib/guestfs/provision/provision.sh
+++ b/contrib/guestfs/provision/provision.sh
@@ -75,6 +75,15 @@ sed -i -e "s/GRUB_CMDLINE_LINUX=.*/GRUB_CMDLINE_LINUX=\"lsm=bpf,integrity\"/" \
     /etc/default/grub
 grub2-mkconfig -o /boot/grub2/grub.cfg
 
+### Add 9p drivers to dracut
+cat >> /etc/dracut.conf.d/90-9p.conf << EOF
+# Add 9p 9pnet and 9pnet_virtio modules
+add_drivers+=" 9p 9pnet 9pnet_virtio "
+EOF
+
+### Rebuild initrd with dracut
+mkinitrd
+
 mv /etc/containerd/config.toml.rpmorig /etc/containerd/config.toml
 
 systemctl enable containerd


### PR DESCRIPTION
Guestfs image needs to have 9p 9pnet 9pnet-virtio drivers included in initrd.
This has to be added to dracut during guestfs image provisioning.