### PR TITLE
bpf: Adjust PID-related BPF map sizes to the current pid_max

### DIFF
--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -17,5 +17,6 @@
     - [File access](policies/file-access.md)
     - [Mount](policies/mount.md)
     - [Syslog](policies/syslog.md)
+- [Tuning](tuning/README.md)
 - [Demos](demos/README.md)
     - [Mount](demos/mount.md)

--- a/docs/src/tuning/README.md
+++ b/docs/src/tuning/README.md
@@ -1,0 +1,37 @@
+## Tuning
+
+This guide shows options and tricks to gain an optimal performance and resouce
+usage.
+
+### Memory usage
+
+Memory usage by lockc depends mostly on BPF maps size. BPF maps are stored in
+memory and the biggest BPF maps are the ones related to tracking processes and
+containers. Size of those maps depends on the limit of processes (in separate
+memory spaces) in the system. That limit is determined by the `kernel.pid_max`
+sysctl. By default the limit is 32768. With such limit, memory usage by lockc
+should be aproximately 10-20 MB.
+
+If you observe too much memory being used after installing lockc, try to check
+the value of `kernel.pid_max`, which can be done with:
+
+```bash
+sudo sysctl kernel.pid_max
+```
+
+Change of that value (i.e. to 10000) can be done with:
+
+```bash
+sudo sysctl kernel.pid_max=10000
+```
+
+But that change will be not persistent after reboot. Changing it persistently
+requires adding a configuration to `/etc/sysctl.d`. I.e. we could create the
+file `/etc/sysctl.d/05-lockc.conf` with the following content:
+
+```
+kernel.pid_max = 10000
+```
+
+After creating that file, the lower limit is going to be persistent after
+reboot.

--- a/lockc/Cargo.toml
+++ b/lockc/Cargo.toml
@@ -37,6 +37,7 @@ procfs = "0.11"
 regex = { version = "1.5", default-features = false, features = ["perf"] }
 serde = "1.0"
 serde_json = "1.0"
+sysctl = "0.4"
 thiserror = "1.0"
 tokio = { version = "1.7", features = ["macros", "process", "rt-multi-thread"] }
 uuid = { version = "0.8", default-features = false, features = ["v4"] }


### PR DESCRIPTION
Before this change, we assumed the worst case scenario about the number
of processes which can be schedules - the upper configurable limit for
x86_64 - which in theory is 4194304.

Allocating such a map size resulted in huge memory usage by lockc BPF
programs, over 500 MB, which is unacceptable for nodes with <=2 GB RAM
(which is usual both in IoT/ARM world and public clouds).

This change reads the currently configured limit by reading the
kernel.pid_max sysctl. On the most of systems it's configured to 32768.
That's way less than the maximum worst case scenario.

Memory usage before this change:

```bash
lockc-control-plane-0:~ # free -m
              total        used        free      shared  buff/cache   available
Mem:           1968         811         689           8         467        1011
Swap:             0           0           0
lockc-control-plane-0:~ # systemctl start lockcd
lockc-control-plane-0:~ # free -m
              total        used        free      shared  buff/cache   available
Mem:           1968        1420         154           8         393         339
Swap:             0           0           0
```

After this change:

```bash
lockc-control-plane-0:~ # free -m
              total        used        free      shared  buff/cache   available
Mem:           1968         793         220           3         955        1037
Swap:             0           0           0
lockc-control-plane-0:~ # systemctl start lockcd
lockc-control-plane-0:~ # free -m
              total        used        free      shared  buff/cache   available
Mem:           1968         803         210           3         955        1028
Swap:             0           0
```

Fixes: #82
Signed-off-by: Michal Rostecki <mrostecki@opensuse.org>