### PR TITLE
Switch to Rust 2021

### DIFF
--- a/lockc/Cargo.toml
+++ b/lockc/Cargo.toml
@@ -2,7 +2,7 @@
 name = "lockc"
 version = "0.1.1"
 authors = ["Michal Rostecki <mrostecki@opensuse.org>"]
-edition = "2018"
+edition = "2021"
 
 description = "eBPF-based MAC security audit for container workloads"
 repository = "https://github.com/rancher-sandbox/lockc"

--- a/lockc/src/bpfstructs.rs
+++ b/lockc/src/bpfstructs.rs
@@ -5,8 +5,6 @@
 #![allow(non_snake_case)]
 include!(concat!(env!("OUT_DIR"), "/bindings.rs"));
 
-use std::convert::TryInto;
-
 use byteorder::{NativeEndian, WriteBytesExt};
 
 #[derive(thiserror::Error, Debug)]

--- a/lockc/src/lib.rs
+++ b/lockc/src/lib.rs
@@ -5,7 +5,7 @@
 #[macro_use]
 extern crate lazy_static;
 
-use std::{convert::TryInto, fs, io, io::prelude::*, num, path};
+use std::{fs, io, io::prelude::*, num, path};
 
 use byteorder::{NativeEndian, WriteBytesExt};
 use sysctl::Sysctl;

--- a/lockc/src/settings.rs
+++ b/lockc/src/settings.rs
@@ -1,5 +1,3 @@
-use std::convert::TryInto;
-
 use crate::bpfstructs;
 
 /// Path to Pseudo-Terminal Device, needed for -it option in container

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "xtask"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 anyhow = "1.0"


### PR DESCRIPTION
Rust 2021 edition comes tiwht Rust 1.56.0. Details about the new
edition:

https://blog.rust-lang.org/2021/10/21/Rust-1.56.0.html

Signed-off-by: Michal Rostecki <mrostecki@opensuse.org>