### PR TITLE
Deploy lockc as a DeamonSet

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,56 @@
+FROM docker.io/library/rust:latest as builder
+RUN wget https://apt.llvm.org/llvm-snapshot.gpg.key && \
+    apt-key add llvm-snapshot.gpg.key && \
+    rm -f llvm-snapshot.gpg.key && \
+    echo "deb http://apt.llvm.org/bullseye/ llvm-toolchain-bullseye-13 main" > /etc/apt/sources.list.d/llvm.list && \
+    apt update && \
+    apt upgrade -y --no-install-recommends && \
+    apt install -y --no-install-recommends \
+        clang-13 \
+        libelf-dev \
+        gcc-multilib \
+        lld-13 \
+        lldb-13 \
+        python3-pip \
+        sudo && \
+    apt purge --auto-remove && \
+    apt clean && \
+    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+# Build libbpf and bpftool from the newest stable kernel sources.
+RUN curl -Lso linux.tar.xz \
+        $(curl -s https://www.kernel.org/ | grep -A1 "latest_link" | grep -Eo '(http|https)://[^"]+') && \
+    tar -xf linux.tar.xz && \
+    cd $(find . -maxdepth 1 -type d -name "linux*") && \
+    cd tools/lib/bpf && \
+    make -j $(nproc) && \
+    make install prefix=/usr && \
+    cd ../../bpf/bpftool && \
+    make -j $(nproc) && \
+    make install prefix=/usr && \
+    cd ../../../.. && \
+    rm -rf linux*
+RUN cargo install libbpf-cargo
+RUN rustup component add \
+        clippy \
+        rustfmt
+
+FROM builder AS build
+WORKDIR /usr/local/src/lockc
+COPY . ./
+ENV CLANG /usr/bin/clang-13
+RUN cargo build
+
+FROM registry.opensuse.org/opensuse/leap-microdnf:15.3 AS lockc-k8s-agent
+ARG PROFILE=debug
+COPY --from=build /usr/local/src/lockc/target/$PROFILE/lockc-k8s-agent /usr/bin/lockc-k8s-agent
+ENTRYPOINT ["/usr/bin/lockc-k8s-agent"]
+
+FROM registry.opensuse.org/opensuse/leap-microdnf:15.3 AS lockc-runc-wrapper
+ARG PROFILE=debug
+COPY --from=build /usr/local/src/lockc/target/$PROFILE/lockc-runc-wrapper /usr/bin/lockc-runc-wrapper
+ENTRYPOINT ["/bin/cp", "-f", "/usr/bin/lockc-runc-wrapper", "/host/opt/bin/lockc-runc-wrapper"]
+
+FROM registry.opensuse.org/opensuse/leap-microdnf:15.3 AS lockcd
+ARG PROFILE=debug
+COPY --from=build /usr/local/src/lockc/target/$PROFILE/lockcd /usr/bin/lockcd
+ENTRYPOINT ["/usr/bin/lockcd"]

--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -1,38 +1,7 @@
-FROM docker.io/library/rust:latest
-RUN wget https://apt.llvm.org/llvm-snapshot.gpg.key && \
-    apt-key add llvm-snapshot.gpg.key && \
-    rm -f llvm-snapshot.gpg.key && \
-    echo "deb http://apt.llvm.org/bullseye/ llvm-toolchain-bullseye-13 main" > /etc/apt/sources.list.d/llvm.list && \
-    apt update && \
-    apt upgrade -y --no-install-recommends && \
-    apt install -y --no-install-recommends \
-        clang-13 \
-        libelf-dev \
-        gcc-multilib \
-        lld-13 \
-        lldb-13 \
-        python3-pip \
-        sudo && \
-    apt purge --auto-remove && \
-    apt clean && \
-    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
-# Build libbpf and bpftool from the newest stable kernel sources.
-RUN curl -Lso linux.tar.xz \
-        $(curl -s https://www.kernel.org/ | grep -A1 "latest_link" | grep -Eo '(http|https)://[^"]+') && \
-    tar -xf linux.tar.xz && \
-    cd $(find . -maxdepth 1 -type d -name "linux*") && \
-    cd tools/lib/bpf && \
-    make -j $(nproc) && \
-    make install prefix=/usr && \
-    cd ../../bpf/bpftool && \
-    make -j $(nproc) && \
-    make install prefix=/usr && \
-    cd ../../../.. && \
-    rm -rf linux*
-RUN cargo install libbpf-cargo
-RUN rustup component add \
-        clippy \
-        rustfmt
+# syntax = edrevo/dockerfile-plus
+INCLUDE+ Dockerfile
+
+FROM builder
 
 ENV DAPPER_SOURCE /source
 ENV DAPPER_OUTPUT target

--- a/contrib/guestfs/build.sh
+++ b/contrib/guestfs/build.sh
@@ -39,7 +39,6 @@ virt-customize -a \
     ${LOCKC_IMAGE} \
     --mkdir /etc/containerd \
     --mkdir /etc/docker \
-    --copy-in provision/etc/containerd/config.toml:/etc/containerd/ \
     --copy-in provision/etc/docker/daemon.json:/etc/docker/ \
     --copy-in provision/etc/modules-load.d/99-k8s.conf:/etc/modules-load.d/ \
     --copy-in provision/etc/sysctl.d/99-k8s.conf:/etc/sysctl.d/ \

--- a/contrib/helm/.helmignore
+++ b/contrib/helm/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/contrib/helm/lockc/.helmignore
+++ b/contrib/helm/lockc/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/contrib/helm/lockc/Chart.yaml
+++ b/contrib/helm/lockc/Chart.yaml
@@ -1,0 +1,13 @@
+apiVersion: v2
+name: lockc
+version: 0.1.0
+description: A Helm chart for Kubernetes lockc agent and daemon
+type: application
+icon: https://github.com/rancher-sandbox/lockc/blob/main/docs/src/images/logo-horizontal-lockc.png
+home: https://rancher-sandbox.github.io/lockc/
+appVersion: "v1.0.0"
+maintainers:
+  - name: Michal Rostecki
+    email: mrostecki@suse.com
+  - name: Michal Jura
+    email: mjura@suse.com

--- a/contrib/helm/lockc/templates/NOTES.txt
+++ b/contrib/helm/lockc/templates/NOTES.txt
@@ -1,0 +1,8 @@
+lockc-agent and lockd installed SUCCESSFULLY
+
+lockc provides three policy levels for containers:
+  * baseline - meant for regular applications
+  * restricted - meant for applications for which we need to be more cautious and secure them more stricly
+  * privileged - meant for part of the infrastructure which can have full access to host resources
+
+For more information checkout https://rancher-sandbox.github.io/lockc/

--- a/contrib/helm/lockc/templates/_helpers.tpl
+++ b/contrib/helm/lockc/templates/_helpers.tpl
@@ -1,0 +1,98 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "lockc.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "lockc.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "lockc.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create lockc labels
+*/}}
+{{- define "lockc.labels" -}}
+helm.sh/chart: {{ include "lockc.chart" . }}
+{{ include "lockc.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector lockc labels
+*/}}
+{{- define "lockc.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "lockc.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create lockcd labels
+*/}}
+{{- define "lockcd.labels" -}}
+helm.sh/chart: {{ include "lockc.chart" . }}
+{{ include "lockcd.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector lockcd labels
+*/}}
+{{- define "lockcd.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "lockc.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create lockc-agent labels
+*/}}
+{{- define "lockc-agent.labels" -}}
+helm.sh/chart: {{ include "lockc.chart" . }}
+{{ include "lockc-agent.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "lockc-agent.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "lockc.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "lockc.serviceAccountName" -}}
+{{- include "lockc.fullname" . }}
+{{- end }}

--- a/contrib/helm/lockc/templates/clusterrole.yaml
+++ b/contrib/helm/lockc/templates/clusterrole.yaml
@@ -1,0 +1,9 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: lockc-agent
+  namespace: {{ .Release.Namespace }}
+rules:
+- apiGroups: [""]
+  resources: ["namespaces"]
+  verbs: ["get", "watch", "list"]

--- a/contrib/helm/lockc/templates/clusterrolebinding.yaml
+++ b/contrib/helm/lockc/templates/clusterrolebinding.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: lockc-agent
+  namespace: {{ .Release.Namespace }}
+subjects:
+- kind: ServiceAccount
+  name: lockc-agent
+  namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: ClusterRole
+  name: lockc-agent
+  apiGroup: rbac.authorization.k8s.io

--- a/contrib/helm/lockc/templates/configmap.yaml
+++ b/contrib/helm/lockc/templates/configmap.yaml
@@ -1,0 +1,68 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: containerd-config
+  namespace: {{ .Release.Namespace }}
+data:
+  config.toml: |
+    version = 2
+    [plugins."io.containerd.grpc.v1.cri"]
+      disable_tcp_service = true
+      stream_server_address = "127.0.0.1"
+      stream_server_port = "0"
+      stream_idle_timeout = "4h"
+      enable_selinux = false
+      sandbox_image = "k8s.gcr.io/pause:3.6"
+      stats_collect_period = 10
+      max_container_log_line_size = 16384
+      disable_cgroup = false
+      disable_apparmor = true
+      restrict_oom_score_adj = false
+      max_concurrent_downloads = 3
+      [plugins."io.containerd.grpc.v1.cri".containerd]
+        default_runtime_name = "runc"
+        [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc]
+          runtime_type = "io.containerd.runc.v2"
+          pod_annotations = []
+          container_annotations = []
+          privileged_without_host_devices = false
+          base_runtime_spec = ""
+          cni_conf_dir = "/etc/cni/net.d"
+          cni_max_conf_num = 1
+          [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc.options]
+            NoPivotRoot = false
+            NoNewKeyring = false
+            ShimCgroup = ""
+            IoUid = 0
+            IoGid = 0
+            BinaryName = "/usr/bin/runc"
+            Root = ""
+            CriuPath = "/usr/sbin/criu"
+            SystemdCgroup = false
+            CriuImagePath = ""
+            CriuWorkPath = ""
+        [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.lockc-runc-wrapper]
+          runtime_type = "io.containerd.runc.v2"
+          pod_annotations = []
+          container_annotations = []
+          privileged_without_host_devices = false
+          base_runtime_spec = ""
+          cni_conf_dir = "/etc/cni/net.d"
+          cni_max_conf_num = 1
+          [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.lockc-runc-wrapper.options]
+            NoPivotRoot = false
+            NoNewKeyring = false
+            ShimCgroup = ""
+            IoUid = 0
+            IoGid = 0
+            BinaryName = "/opt/bin/lockc-runc-wrapper"
+            Root = ""
+            CriuPath = "/usr/sbin/criu"
+            SystemdCgroup = false
+            CriuImagePath = ""
+            CriuWorkPath = ""
+      [plugins."io.containerd.grpc.v1.cri".cni]
+        bin_dir = "/opt/cni/bin"
+        conf_dir = "/etc/cni/net.d"
+        max_conf_num = 1
+        ip_pref = "cni"

--- a/contrib/helm/lockc/templates/daemonset-agent.yaml
+++ b/contrib/helm/lockc/templates/daemonset-agent.yaml
@@ -1,0 +1,40 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: lockc-agent
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "lockc-agent.labels" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "lockc-agent.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "lockc-agent.selectorLabels" . | nindent 8 }}
+    spec:
+      containers:
+      - name: lockc-agent
+        image: "{{ .Values.lockcAgent.image.repository }}:{{ .Values.lockcAgent.image.tag | default .Chart.AppVersion }}"
+        imagePullPolicy: {{ .Values.lockcAgent.image.pullPolicy }}
+        env:
+        - name: RUST_LOG
+          value: info
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8080
+          initialDelaySeconds: 3
+          periodSeconds: 3
+        volumeMounts:
+        - name: runlockc
+          mountPath: /run/lockc
+      serviceAccountName: {{ include "lockc.serviceAccountName" . }}
+      tolerations:
+      - operator: Exists
+      volumes:
+      - name: runlockc
+        hostPath:
+          path: /run/lockc
+

--- a/contrib/helm/lockc/templates/daemonset-lockcd.yaml
+++ b/contrib/helm/lockc/templates/daemonset-lockcd.yaml
@@ -1,0 +1,88 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: lockcd
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "lockcd.labels" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "lockcd.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "lockcd.selectorLabels" . | nindent 8 }}
+    spec:
+      hostPID: true
+      initContainers:
+      - name: install-lockc-runc-wrapper
+        image: "{{ .Values.lockcRuncWrapper.image.repository }}:{{ .Values.lockcRuncWrapper.image.tag | default .Chart.AppVersion }}"
+        imagePullPolicy: {{ .Values.lockcRuncWrapper.image.pullPolicy }}
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - name: opt-bin
+          mountPath: /host/opt/bin
+      - name: install-containerd-config
+        image: debian:latest
+        imagePullPolicy: Always
+        command:
+        - cp
+        - -f
+        - /config/config.toml
+        - /host/etc/containerd/config.toml
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - name: etc-containerd
+          mountPath: /host/etc/containerd
+        - name: containerd-config
+          mountPath: /config
+      - name: restart-containerd
+        image: debian:latest
+        imagePullPolicy: Always
+        command:
+        - "nsenter"
+        - "-t"
+        - "1"
+        - "-m"
+        - "--"
+        - "/usr/bin/systemctl"
+        - "restart"
+        - "containerd"
+        securityContext:
+          privileged: true
+      containers:
+      - name: lockcd
+        image: "{{ .Values.lockcd.image.repository }}:{{ .Values.lockcd.image.tag | default .Chart.AppVersion }}"
+        imagePullPolicy: {{ .Values.lockcd.image.pullPolicy }}
+        securityContext:
+          privileged: true
+        env:
+        - name: LOCKC_CHECK_LSM_SKIP
+          value: "1"
+        volumeMounts:
+        - name: bpffs
+          mountPath: /sys/fs/bpf
+      tolerations:
+      - operator: Exists
+      volumes:
+      - name: bpffs
+        hostPath:
+          path: /sys/fs/bpf
+          type: Directory
+      - name: opt-bin
+        hostPath:
+          path: /opt/bin
+          type: DirectoryOrCreate
+      - name: etc-containerd
+        hostPath:
+          path: /etc/containerd
+          type: DirectoryOrCreate
+      - name: containerd-config
+        configMap:
+          name: containerd-config
+          items:
+          - key: "config.toml"
+            path: "config.toml"

--- a/contrib/helm/lockc/templates/runtimeclass.yaml
+++ b/contrib/helm/lockc/templates/runtimeclass.yaml
@@ -1,0 +1,5 @@
+apiVersion: node.k8s.io/v1
+kind: RuntimeClass
+metadata:
+  name: lockc-runc-wrapper
+handler: lockc-runc-wrapper

--- a/contrib/helm/lockc/templates/serviceaccount.yaml
+++ b/contrib/helm/lockc/templates/serviceaccount.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "lockc.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "lockc.labels" . | nindent 4 }}

--- a/contrib/helm/lockc/values.yaml
+++ b/contrib/helm/lockc/values.yaml
@@ -1,0 +1,17 @@
+lockcd:
+  image:
+    repository: docker.io/vadorovsky/lockcd
+    pullPolicy: IfNotPresent
+    tag: "latest"
+
+lockcRuncWrapper:
+  image:
+    repository: docker.io/vadorovsky/lockc-runc-wrapper
+    pullPolicy: IfNotPresent
+    tag: "latest"
+
+lockcAgent:
+  image:
+    repository: docker.io/vadorovsky/lockc-k8s-agent
+    pullPolicy: IfNotPresent
+    tag: "latest"

--- a/contrib/kubernetes/kubewarden.yaml
+++ b/contrib/kubernetes/kubewarden.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: policies.kubewarden.io/v1alpha2
+kind: ClusterAdmissionPolicy
+metadata:
+  name: pod-runtime-lockc-runc-wrapper
+spec:
+  module: registry://ghcr.io/kubewarden/policies/pod-runtime:v0.1.3
+  rules:
+  - apiGroups: [""]
+    apiVersions: ["v1"]
+    resources: ["pods"]
+    operations:
+    - CREATE
+    - UPDATE
+  mutating: true
+  settings:
+    reservedRuntimes:
+    - runC
+    fallbackRuntime: lockc-runc-wrapper
+    defaultRuntimeReserved: true

--- a/contrib/kubernetes/lockc.yaml
+++ b/contrib/kubernetes/lockc.yaml
@@ -1,0 +1,234 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: containerd
+  namespace: kube-system
+data:
+  config.toml: |
+    version = 2
+    [plugins."io.containerd.grpc.v1.cri"]
+      disable_tcp_service = true
+      stream_server_address = "127.0.0.1"
+      stream_server_port = "0"
+      stream_idle_timeout = "4h"
+      enable_selinux = false
+      sandbox_image = "k8s.gcr.io/pause:3.6"
+      stats_collect_period = 10
+      max_container_log_line_size = 16384
+      disable_cgroup = false
+      disable_apparmor = true
+      restrict_oom_score_adj = false
+      max_concurrent_downloads = 3
+      [plugins."io.containerd.grpc.v1.cri".containerd]
+        default_runtime_name = "runc"
+        [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc]
+          runtime_type = "io.containerd.runc.v2"
+          pod_annotations = []
+          container_annotations = []
+          privileged_without_host_devices = false
+          base_runtime_spec = ""
+          cni_conf_dir = "/etc/cni/net.d"
+          cni_max_conf_num = 1
+          [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc.options]
+            NoPivotRoot = false
+            NoNewKeyring = false
+            ShimCgroup = ""
+            IoUid = 0
+            IoGid = 0
+            BinaryName = "/usr/bin/runc"
+            Root = ""
+            CriuPath = "/usr/sbin/criu"
+            SystemdCgroup = false
+            CriuImagePath = ""
+            CriuWorkPath = ""
+        [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.lockc-runc-wrapper]
+          runtime_type = "io.containerd.runc.v2"
+          pod_annotations = []
+          container_annotations = []
+          privileged_without_host_devices = false
+          base_runtime_spec = ""
+          cni_conf_dir = "/etc/cni/net.d"
+          cni_max_conf_num = 1
+          [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.lockc-runc-wrapper.options]
+            NoPivotRoot = false
+            NoNewKeyring = false
+            ShimCgroup = ""
+            IoUid = 0
+            IoGid = 0
+            BinaryName = "/opt/bin/lockc-runc-wrapper"
+            Root = ""
+            CriuPath = "/usr/sbin/criu"
+            SystemdCgroup = false
+            CriuImagePath = ""
+            CriuWorkPath = ""
+      [plugins."io.containerd.grpc.v1.cri".cni]
+        bin_dir = "/opt/cni/bin"
+        conf_dir = "/etc/cni/net.d"
+        max_conf_num = 1
+        ip_pref = "cni"
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: lockcd
+  namespace: kube-system
+  labels:
+    k8s-app: lockcd
+spec:
+  selector:
+    matchLabels:
+      name: lockcd
+  template:
+    metadata:
+      labels:
+        name: lockcd
+    spec:
+      hostPID: true
+      containers:
+      - name: lockcd
+        image: docker.io/vadorovsky/lockcd:latest
+        imagePullPolicy: Always
+        securityContext:
+          privileged: true
+        env:
+        - name: LOCKC_CHECK_LSM_SKIP
+          value: "1"
+        volumeMounts:
+        - name: bpffs
+          mountPath: /sys/fs/bpf
+      initContainers:
+      - name: install-lockc-runc-wrapper
+        image: docker.io/vadorovsky/lockc-runc-wrapper:latest
+        imagePullPolicy: Always
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - name: opt-bin
+          mountPath: /host/opt/bin
+      - name: install-containerd-config
+        image: busybox:latest
+        imagePullPolicy: Always
+        command:
+        - cp
+        - -f
+        - /config/config.toml
+        - /host/etc/containerd/config.toml
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - name: etc-containerd
+          mountPath: /host/etc/containerd
+        - name: containerd-config
+          mountPath: /config
+      - name: restart-containerd
+        image: busybox:latest
+        imagePullPolicy: Always
+        command:
+        - "nsenter"
+        - "-t"
+        - "1"
+        - "-m"
+        - "--"
+        - "/usr/bin/systemctl"
+        - "restart"
+        - "containerd"
+        securityContext:
+          privileged: true
+      tolerations:
+      - operator: Exists
+      volumes:
+      - name: bpffs
+        hostPath:
+          path: /sys/fs/bpf
+          type: Directory
+      - name: opt-bin
+        hostPath:
+          path: /opt/bin
+          type: DirectoryOrCreate
+      - name: etc-containerd
+        hostPath:
+          path: /etc/containerd
+          type: DirectoryOrCreate
+      - name: containerd-config
+        configMap:
+          name: containerd
+          items:
+          - key: "config.toml"
+            path: "config.toml"
+---
+apiVersion: node.k8s.io/v1
+kind: RuntimeClass
+metadata:
+  name: lockc-runc-wrapper
+handler: lockc-runc-wrapper
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: lockc-k8s-agent
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: lockc-k8s-agent
+  namespace: kube-system
+rules:
+- apiGroups: [""]
+  resources: ["namespaces"]
+  verbs: ["get", "watch", "list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: lockc-k8s-agent
+  namespace: kube-system
+subjects:
+- kind: ServiceAccount
+  name: lockc-k8s-agent
+  namespace: kube-system
+roleRef:
+  kind: ClusterRole
+  name: lockc-k8s-agent
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: lockc-k8s-agent
+  namespace: kube-system
+  labels:
+    k8s-app: lockc-k8s-agent
+spec:
+  selector:
+    matchLabels:
+      name: lockc-k8s-agent
+  template:
+    metadata:
+      labels:
+        name: lockc-k8s-agent
+    spec:
+      containers:
+      - name: lockc-k8s-agent
+        image: docker.io/vadorovsky/lockc-k8s-agent:latest
+        imagePullPolicy: Always
+        env:
+        - name: RUST_LOG
+          value: info
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8080
+          initialDelaySeconds: 3
+          periodSeconds: 3
+        volumeMounts:
+        - name: runlockc
+          mountPath: /run/lockc
+      serviceAccountName: lockc-k8s-agent
+      tolerations:
+      - operator: Exists
+      volumes:
+      - name: runlockc
+        hostPath:
+          path: /run/lockc

--- a/contrib/kubernetes/registry.yaml
+++ b/contrib/kubernetes/registry.yaml
@@ -1,0 +1,25 @@
+---
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: registry-pv
+  namespace: kube-system
+spec:
+  capacity:
+    storage: 1Gi
+  accessModes:
+  - ReadWriteOnce
+  hostPath:
+    path: /tmp/repository
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: docker-repo-pvc
+  namespace: kube-system
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi

--- a/contrib/terraform/libvirt/cloud-init/common.tpl
+++ b/contrib/terraform/libvirt/cloud-init/common.tpl
@@ -8,14 +8,14 @@ mounts:
   - [ lockc, /usr/local/src/lockc, 9p, "trans=virtio,version=9p2000.L,rw", "0", "0" ]
 
 users:
-  - name: opensuse
+  - name: ${username}
     groups: users, docker
     sudo: ALL=(ALL) NOPASSWD:ALL
     ssh_authorized_keys:
 ${authorized_keys}
 
 runcmd:
+  - pushd /usr/local/src/lockc
   - install-lockc.sh
-  - systemctl restart containerd.service
-  - systemctl enable --now lockcd.service
+  - popd
 ${commands}

--- a/contrib/terraform/libvirt/cloud-init/control-plane.tpl
+++ b/contrib/terraform/libvirt/cloud-init/control-plane.tpl
@@ -1,8 +1,19 @@
-  - kubeadm init --cri-socket /run/containerd/containerd.sock
+  - kubeadm init --cri-socket /run/containerd/containerd.sock --token ${kubeadm_token}
   - mkdir -p /home/opensuse/.kube
   - sudo cp -i /etc/kubernetes/admin.conf /home/opensuse/.kube/config
   - sudo chown opensuse /home/opensuse/.kube/config
-%{ if workers == "0" }
   - export KUBECONFIG=/etc/kubernetes/admin.conf
+%{ if workers == "0" }
   - kubectl taint nodes $(kubectl get nodes --selector=node-role.kubernetes.io/master | awk 'FNR==2{print $1}') node-role.kubernetes.io/master-
 %{ endif }
+  - cilium install
+  - helm repo add jetstack https://charts.jetstack.io
+  - helm repo add kubewarden https://charts.kubewarden.io
+  - helm repo update
+  - kubectl apply -f https://github.com/jetstack/cert-manager/releases/download/v1.6.0/cert-manager.yaml
+  - kubectl wait --for=condition=Available deployment --timeout=2m -n cert-manager --all
+  - helm install -n kube-system kubewarden-crds kubewarden/kubewarden-crds
+  - helm install --wait -n kube-system kubewarden-controller kubewarden/kubewarden-controller
+  - kubectl apply -f /usr/local/src/lockc/contrib/kubernetes/lockc.yaml
+  - kubectl wait --for=condition=Available daemonset --timeout=2m -n lockcd --all
+  - kubectl apply -f /usr/local/src/lockc/contrib/kubernetes/kubewarden.yaml

--- a/contrib/terraform/libvirt/cloud-init/worker.tpl
+++ b/contrib/terraform/libvirt/cloud-init/worker.tpl
@@ -1,0 +1,1 @@
+  - kubeadm join ${control_plane_ip}:6443 --cri-socket /run/containerd/containerd.sock --token ${kubeadm_token} --discovery-token-unsafe-skip-ca-verification

--- a/contrib/terraform/libvirt/control-plane.tf
+++ b/contrib/terraform/libvirt/control-plane.tf
@@ -4,12 +4,12 @@ resource "libvirt_volume" "control_plane" {
   count          = var.control_planes
 }
 
-
 data "template_file" "control_plane_commands" {
   template = file("cloud-init/control-plane.tpl")
 
   vars = {
     workers = var.workers
+    kubeadm_token = var.kubeadm_token
   }
 }
 
@@ -21,6 +21,7 @@ data "template_file" "control_plane_cloud_init" {
     hostname        = "lockc-control-plane-${count.index}"
     locale          = var.locale
     timezone        = var.timezone
+    username        = var.username
     authorized_keys = join("\n", formatlist("      - %s", var.authorized_keys))
     commands        = join("\n", data.template_file.control_plane_commands.*.rendered)
   }

--- a/contrib/terraform/libvirt/main.tf
+++ b/contrib/terraform/libvirt/main.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     libvirt = {
-      source  = "dmacvicar/libvirt"
+      source = "dmacvicar/libvirt"
     }
   }
 }

--- a/contrib/terraform/libvirt/output.tf
+++ b/contrib/terraform/libvirt/output.tf
@@ -4,3 +4,10 @@ output "ip_control_planes" {
     libvirt_domain.control_plane.*.network_interface.0.addresses,
   )
 }
+
+output "ip_workers" {
+  value = zipmap(
+    libvirt_domain.worker.*.network_interface.0.hostname,
+    libvirt_domain.worker.*.network_interface.0.addresses,
+  )
+}

--- a/contrib/terraform/libvirt/terraform.tfvars.json.example
+++ b/contrib/terraform/libvirt/terraform.tfvars.json.example
@@ -12,6 +12,7 @@
   "authorized_keys": [
     ""
   ],
+  "kubeadm_token": "8c05f4.b5bdd4ceb5ce4d3f",
   "control_planes": 1,
   "control_plane_memory": 2048,
   "control_plane_vcpu": 2,

--- a/contrib/terraform/libvirt/variables.tf
+++ b/contrib/terraform/libvirt/variables.tf
@@ -48,10 +48,20 @@ variable "timezone" {
   default     = "Etc/UTC"
 }
 
+variable "username" {
+  description = "Default user on the nodes"
+  default     = "opensuse"
+}
+
 variable "authorized_keys" {
   description = "SSH keys to inject into all the nodes"
   type        = list(string)
   default     = []
+}
+
+variable "kubeadm_token" {
+  description = "Token for trust between kubeadm nodes"
+  default     = "8c05f4.b5bdd4ceb5ce4d3f"
 }
 
 variable "control_planes" {

--- a/contrib/terraform/libvirt/worker.tf
+++ b/contrib/terraform/libvirt/worker.tf
@@ -1,0 +1,69 @@
+resource "libvirt_volume" "worker" {
+  name           = "lockc-worker-volume-${count.index}"
+  base_volume_id = libvirt_volume.lockc_image.id
+  count          = var.workers
+}
+
+data "template_file" "worker_commands" {
+  template = file("cloud-init/worker.tpl")
+
+  vars = {
+    control_plane_ip = length(libvirt_domain.control_plane.0.network_interface.0.addresses) == 0 ? "" : libvirt_domain.control_plane.0.network_interface.0.addresses.0
+    kubeadm_token    = var.kubeadm_token
+  }
+}
+
+data "template_file" "worker_cloud_init" {
+  template = file("cloud-init/common.tpl")
+  count    = var.workers
+
+  vars = {
+    hostname        = "lockc-worker-${count.index}"
+    locale          = var.locale
+    timezone        = var.timezone
+    username        = var.username
+    authorized_keys = join("\n", formatlist("      - %s", var.authorized_keys))
+    commands        = join("\n", data.template_file.worker_commands.*.rendered)
+  }
+}
+
+resource "libvirt_cloudinit_disk" "worker" {
+  count     = var.workers
+  name      = "lockc-worker-cloudinit-disk-${count.index}"
+  pool      = var.pool
+  user_data = data.template_file.worker_cloud_init[count.index].rendered
+}
+
+resource "libvirt_domain" "worker" {
+  count     = var.workers
+  name      = "lockc-worker-${count.index}"
+  memory    = var.control_plane_memory
+  vcpu      = var.control_plane_vcpu
+  cloudinit = element(libvirt_cloudinit_disk.worker.*.id, count.index)
+
+  cpu {
+    mode = "host-passthrough"
+  }
+
+  disk {
+    volume_id = element(libvirt_volume.worker.*.id, count.index)
+  }
+
+  # Mount the source code.
+  filesystem {
+    source   = "${path.cwd}/../../.."
+    target   = "lockc"
+    readonly = false
+  }
+
+  network_interface {
+    network_name   = var.network_name
+    hostname       = "lockc-worker-${count.index}"
+    wait_for_lease = true
+  }
+
+  graphics {
+    type        = "vnc"
+    listen_type = "address"
+  }
+}

--- a/contrib/terraform/openstack/output.tf
+++ b/contrib/terraform/openstack/output.tf
@@ -7,14 +7,14 @@ output "ip_masters" {
     )
 }
 
-output "ip_workers" {
-  value = zipmap(
-    concat(
-      openstack_compute_instance_v2.worker.*.name, [ for i in range(length(openstack_compute_instance_v2.worker), var.workers) : format("worker-%d (not provisioned)", i ) ]),
-    concat(
-      openstack_networking_floatingip_v2.worker_ext.*.address,  [ for _ in range(length(openstack_networking_floatingip_v2.worker_ext.*.address), var.workers) : "" ])
-  )
-}
+#output "ip_workers" {
+#  value = zipmap(
+#    concat(
+#      openstack_compute_instance_v2.worker.*.name, [ for i in range(length(openstack_compute_instance_v2.worker), var.workers) : format("worker-%d (not provisioned)", i ) ]),
+#    concat(
+#      openstack_networking_floatingip_v2.worker_ext.*.address,  [ for _ in range(length(openstack_networking_floatingip_v2.worker_ext.*.address), var.workers) : "" ])
+#  )
+#}
 
 output "ip_internal_load_balancer" {
   value = openstack_lb_loadbalancer_v2.lb.vip_address

--- a/lockc/Cargo.toml
+++ b/lockc/Cargo.toml
@@ -17,13 +17,18 @@ name = "lockc"
 
 [dependencies]
 anyhow = "1.0"
+axum = "0.2"
 bincode = "1.3"
 bindgen = "0.59"
 byteorder = "1.4"
 chrono = { version = "0.4", default-features = false, features = ["clock"] }
+clap = "2.33"
 config = { version = "0.11", default-features = false, features = ["toml"] }
+ctrlc = "3.2"
 dirs = "4.0"
 futures = "0.3"
+hyper = "0.14"
+hyperlocal = "0.8"
 kube = "0.63"
 k8s-openapi = { version = "0.13", default-features = false, features = ["v1_21"] }
 lazy_static = "1.4"
@@ -40,6 +45,10 @@ serde_json = "1.0"
 sysctl = "0.4"
 thiserror = "1.0"
 tokio = { version = "1.7", features = ["macros", "process", "rt-multi-thread"] }
+tower = "0.4"
+tower-http = "0.1"
+tracing = "0.1"
+tracing-subscriber = "0.2"
 uuid = { version = "0.8", default-features = false, features = ["v4"] }
 
 [build-dependencies]
@@ -51,4 +60,4 @@ tempfile = "3.2"
 thiserror = "1.0"
 
 [dev-dependencies]
-tempfile = "3.2.0"
+tempfile = "3.2"

--- a/lockc/src/bin/lockc-k8s-agent.rs
+++ b/lockc/src/bin/lockc-k8s-agent.rs
@@ -1,0 +1,211 @@
+// use std::{fs, path};
+use std::{
+    convert::Infallible,
+    net::SocketAddr,
+    pin::Pin,
+    task::{Context, Poll},
+};
+
+use axum::{
+    body::{Bytes, Full},
+    handler::get,
+    http::{Response, StatusCode},
+    response::IntoResponse,
+    Json, Router,
+};
+use futures::ready;
+use hyper::server::accept::Accept;
+use k8s_openapi::api::core::v1;
+use serde::Deserialize;
+use serde_json::json;
+use thiserror::Error;
+use tokio::net::{UnixListener, UnixStream};
+use tower::{BoxError, ServiceBuilder};
+use tower_http::trace::TraceLayer;
+
+use lockc::{
+    bpfstructs,
+    k8s_agent_api::{Policies, ServerStatus, DEFAULT_SOCKET_PATH},
+};
+
+// static APP_NAME: &str = "lockc-runc-wrapper";
+
+static DEFAULT_HEALTH_ADDRESS: &str = "0.0.0.0:8080";
+
+static STATUS_OK: &str = "ok";
+
+static LABEL_POLICY_ENFORCE: &str = "pod-security.kubernetes.io/enforce";
+static LABEL_POLICY_ENFORCE_VERSION: &str = "pod-security.kubernetes.io/enforce-version";
+static LABEL_POLICY_AUDIT: &str = "pod-security.kubernetes.io/audit";
+static LABEL_POLICY_AUDIT_VERSION: &str = "pod-security.kubernetes.io/audit-version";
+static LABEL_POLICY_WARN: &str = "pod-security.kubernetes.io/warn";
+static LABEL_POLICY_WARN_VERSION: &str = "pod-security.kubernetes-io/warn-version";
+
+static DEFAULT_POLICY_VERSION: &str = "v1.22";
+
+#[derive(Error, Debug)]
+enum GetPoliciesError {
+    #[error(transparent)]
+    Kube(#[from] kube::Error),
+
+    #[error(transparent)]
+    PolicyLevel(#[from] bpfstructs::PolicyLevelError),
+}
+
+impl IntoResponse for GetPoliciesError {
+    type Body = Full<Bytes>;
+    type BodyError = Infallible;
+
+    fn into_response(self) -> Response<Self::Body> {
+        let body = Json(json!({"error": self.to_string()}));
+
+        (StatusCode::INTERNAL_SERVER_ERROR, body).into_response()
+    }
+}
+
+/// Gets policies and their versions from Kubernetes namespace labels.
+async fn get_policies(namespace: &str) -> Result<Policies, GetPoliciesError> {
+    // Apply the privileged policy for kube-system containers immediately.
+    // Otherwise the core k8s components (apiserver, scheduler) won't be able
+    // to run.
+    // If container has no k8s namespace, apply the baseline policy.
+    if namespace == "kube-system" {
+        return Ok(Policies {
+            enforce: bpfstructs::container_policy_level_POLICY_LEVEL_PRIVILEGED,
+            enforce_version: DEFAULT_POLICY_VERSION.to_string(),
+            audit: bpfstructs::container_policy_level_POLICY_LEVEL_PRIVILEGED,
+            audit_version: DEFAULT_POLICY_VERSION.to_string(),
+            warn: bpfstructs::container_policy_level_POLICY_LEVEL_PRIVILEGED,
+            warn_version: DEFAULT_POLICY_VERSION.to_string(),
+        });
+    }
+
+    let client = kube::Client::try_default().await?;
+
+    let namespaces: kube::api::Api<v1::Namespace> = kube::api::Api::all(client);
+    let namespace = namespaces.get(namespace).await?;
+
+    // Try to get policy levels and versions from appropriate labels. If labels
+    // do not exist, apply the default values.
+    match namespace.metadata.labels {
+        Some(v) => Ok(Policies {
+            enforce: match v.get(LABEL_POLICY_ENFORCE) {
+                Some(p) => bpfstructs::policy_level_from_str(p)?,
+                None => bpfstructs::container_policy_level_POLICY_LEVEL_BASELINE,
+            },
+            enforce_version: match v.get(LABEL_POLICY_ENFORCE_VERSION) {
+                Some(ver) => ver.to_string(),
+                None => DEFAULT_POLICY_VERSION.to_string(),
+            },
+            audit: match v.get(LABEL_POLICY_AUDIT) {
+                Some(p) => bpfstructs::policy_level_from_str(p)?,
+                None => bpfstructs::container_policy_level_POLICY_LEVEL_BASELINE,
+            },
+            audit_version: match v.get(LABEL_POLICY_AUDIT_VERSION) {
+                Some(ver) => ver.to_string(),
+                None => DEFAULT_POLICY_VERSION.to_string(),
+            },
+            warn: match v.get(LABEL_POLICY_WARN) {
+                Some(p) => bpfstructs::policy_level_from_str(p)?,
+                None => bpfstructs::container_policy_level_POLICY_LEVEL_BASELINE,
+            },
+            warn_version: match v.get(LABEL_POLICY_WARN_VERSION) {
+                Some(ver) => ver.to_string(),
+                None => DEFAULT_POLICY_VERSION.to_string(),
+            },
+        }),
+        None => Ok(Policies {
+            enforce: bpfstructs::container_policy_level_POLICY_LEVEL_BASELINE,
+            enforce_version: DEFAULT_POLICY_VERSION.to_string(),
+            audit: bpfstructs::container_policy_level_POLICY_LEVEL_BASELINE,
+            audit_version: DEFAULT_POLICY_VERSION.to_string(),
+            warn: bpfstructs::container_policy_level_POLICY_LEVEL_BASELINE,
+            warn_version: DEFAULT_POLICY_VERSION.to_string(),
+        }),
+    }
+}
+
+async fn handler_index() -> impl IntoResponse {
+    (
+        StatusCode::OK,
+        Json(ServerStatus {
+            status: STATUS_OK.to_string(),
+        }),
+    )
+}
+
+#[derive(Deserialize)]
+struct GetPolicies {
+    namespace: String,
+}
+
+async fn handler_policies(
+    Json(payload): Json<GetPolicies>,
+) -> Result<Json<Policies>, GetPoliciesError> {
+    let policies = get_policies(&payload.namespace).await?;
+    Ok(Json(policies))
+}
+
+// #[get("/healthz")]
+// async fn health() -> Result<HttpResponse, Error> {
+//     Ok(HttpResponse::Ok().json(ServerStatus {
+//         status: STATUS_OK.to_string(),
+//     }))
+// }
+
+struct ServerAccept {
+    uds: UnixListener,
+}
+
+impl Accept for ServerAccept {
+    type Conn = UnixStream;
+    type Error = BoxError;
+
+    fn poll_accept(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Option<Result<Self::Conn, Self::Error>>> {
+        let (stream, _addr) = ready!(self.uds.poll_accept(cx))?;
+        Poll::Ready(Some(Ok(stream)))
+    }
+}
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    // initialize tracing
+    tracing_subscriber::fmt::init();
+
+    let middleware_stack = ServiceBuilder::new()
+        // `TraceLayer` adds high level tracing and logging
+        .layer(TraceLayer::new_for_http())
+        .into_inner();
+
+    // build our application with a route
+    let app = Router::new()
+        .route("/", get(handler_index))
+        .route("/policies", get(handler_policies))
+        .layer(middleware_stack.clone());
+
+    // run our app with hyper
+    // `axum::Server` is a re-export of `hyper::Server`
+    // let addr = SocketAddr::from(([127, 0, 0, 1], 3000));
+    tracing::info!("listening on {}", DEFAULT_SOCKET_PATH);
+    let uds = UnixListener::bind(DEFAULT_SOCKET_PATH)?;
+    let uds_server = axum::Server::builder(ServerAccept { uds }).serve(app.into_make_service());
+    let uds_server_task = tokio::spawn(uds_server);
+    // .await?;
+
+    let health_app = Router::new()
+        .route("/healthz", get(handler_index))
+        .layer(middleware_stack);
+    let addr: SocketAddr = DEFAULT_HEALTH_ADDRESS.parse()?;
+    tracing::info!("listening on {}", DEFAULT_HEALTH_ADDRESS);
+    let healthz_server = axum::Server::bind(&addr).serve(health_app.into_make_service());
+    let healthz_server_task = tokio::spawn(healthz_server);
+
+    uds_server_task.await??;
+    healthz_server_task.await??;
+    // .await?;
+
+    Ok(())
+}

--- a/lockc/src/bin/lockcd.rs
+++ b/lockc/src/bin/lockcd.rs
@@ -1,13 +1,26 @@
-use std::path;
+use std::{
+    env, path,
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc,
+    },
+    thread, time,
+};
 
 use chrono::prelude::*;
 
 fn main() -> anyhow::Result<()> {
-    let sys_lsm_path = path::Path::new("/sys")
-        .join("kernel")
-        .join("security")
-        .join("lsm");
-    lockc::check_bpf_lsm_enabled(sys_lsm_path)?;
+    let check_lsm = match env::var("LOCKC_CHECK_LSM_SKIP") {
+        Ok(_) => false,
+        Err(_) => true,
+    };
+    if check_lsm {
+        let sys_lsm_path = path::Path::new("/sys")
+            .join("kernel")
+            .join("security")
+            .join("lsm");
+        lockc::check_bpf_lsm_enabled(sys_lsm_path)?;
+    }
 
     let now = Utc::now();
     let dirname = now.format("%s").to_string();
@@ -22,6 +35,16 @@ fn main() -> anyhow::Result<()> {
 
     lockc::load_programs(path_base_ts)?;
     lockc::cleanup(path_base, &dirname)?;
+
+    let running = Arc::new(AtomicBool::new(true));
+    let r = running.clone();
+    ctrlc::set_handler(move || {
+        r.store(false, Ordering::SeqCst);
+    })?;
+    while running.load(Ordering::SeqCst) {
+        eprint!(".");
+        thread::sleep(time::Duration::from_secs(1));
+    }
 
     Ok(())
 }

--- a/lockc/src/bpfstructs.rs
+++ b/lockc/src/bpfstructs.rs
@@ -10,17 +10,33 @@ use std::convert::TryInto;
 use byteorder::{NativeEndian, WriteBytesExt};
 
 #[derive(thiserror::Error, Debug)]
+pub enum PolicyLevelError {
+    #[error("invalid policy level")]
+    InvalidPolicyLevelError,
+}
+
+/// Converts the string into a policy level.
+pub fn policy_level_from_str(val: &str) -> Result<container_policy_level, PolicyLevelError> {
+    match val {
+        "restricted" => Ok(container_policy_level_POLICY_LEVEL_RESTRICTED),
+        "baseline" => Ok(container_policy_level_POLICY_LEVEL_BASELINE),
+        "privileged" => Ok(container_policy_level_POLICY_LEVEL_PRIVILEGED),
+        _ => Err(PolicyLevelError::InvalidPolicyLevelError),
+    }
+}
+
+#[derive(thiserror::Error, Debug)]
 pub enum NewBpfstructError {
-    #[error("FFI nul error")]
+    #[error(transparent)]
     NulError(#[from] std::ffi::NulError),
 }
 
 #[derive(thiserror::Error, Debug)]
 pub enum MapOperationError {
-    #[error("could not convert the key to a byte array")]
+    #[error(transparent)]
     ByteWriteError(#[from] std::io::Error),
 
-    #[error("libbpf error")]
+    #[error(transparent)]
     LibbpfError(#[from] libbpf_rs::Error),
 }
 

--- a/lockc/src/k8s_agent_api.rs
+++ b/lockc/src/k8s_agent_api.rs
@@ -1,0 +1,28 @@
+use serde::{Deserialize, Serialize};
+
+use super::bpfstructs;
+
+pub static DEFAULT_SOCKET_PATH: &str = "/run/lockc/lockc-k8s-agent.sock";
+
+/// JSON object for returning errors in a response body.
+#[derive(Deserialize, Serialize)]
+pub struct ErrorObj {
+    pub error: String,
+}
+
+/// Server health check status.
+#[derive(Deserialize, Serialize)]
+pub struct ServerStatus {
+    pub status: String,
+}
+
+/// JSON representation of policies.
+#[derive(Deserialize, Serialize)]
+pub struct Policies {
+    pub enforce: bpfstructs::container_policy_level,
+    pub enforce_version: String,
+    pub audit: bpfstructs::container_policy_level,
+    pub audit_version: String,
+    pub warn: bpfstructs::container_policy_level,
+    pub warn_version: String,
+}

--- a/scripts/container-build.sh
+++ b/scripts/container-build.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+CONTAINER_ENGINE=${CONTAINER_ENGINE:-docker}
+LOCKC_BUILD_PROFILE=${LOCKC_BUILD_PROFILE:-debug}
+LOCKC_REGISTRY=${LOCKC_REGISTRY:-docker.io}
+LOCKC_REGISTRY_USER=${LOCKC_REGISTRY_USER:-$(whoami)}
+LOCKC_PUSH=${LOCKC_PUSH:-"false"}
+
+IMAGES="lockc-k8s-agent lockc-runc-wrapper lockcd"
+
+for image in ${IMAGES}; do
+    echo "Building ${image}"
+    ${CONTAINER_ENGINE} build \
+        -t ${LOCKC_REGISTRY}/${LOCKC_REGISTRY_USER}/${image} \
+        --build-arg PROFILE=${LOCKC_BUILD_PROFILE} \
+        --target ${image} \
+        .
+    echo "Image ${image} build"
+
+    if [[ ${LOCKC_PUSH} == "true" ]]; then
+        ${CONTAINER_ENGINE} push ${LOCKC_REGISTRY}/${LOCKC_REGISTRY_USER}/${image}
+        echo "Image ${image} pushed"
+    fi
+done


### PR DESCRIPTION
**This PR is not fully functional yet, just showing progress**

This change makes lockc deployable on Kubernetes by simply doing

```
kubectl apply -f contrib/kubernetes/lockc.yaml
```

That way:

* lockcd is deployed as a DaemonSet
* lockc-runc-wrapper is installed on the host by the init container
* a new component, lockc-k8s-agent, gets deployed as a DaemonSet and its
  purpose is to serve a small API via UNIX socket which lets
  lockc-runc-wrapper now what kind of policy should be applied for which
  k8s namespace

Container images can be built with:

```
./scripts/container-build.sh
```

or also pushed with:

```
LOCKC_PUSH=true ./scripts/container-build.sh
```

Signed-off-by: Michal Rostecki <mrostecki@opensuse.org>