### PR TITLE
docker: Use openSUSE Leap as a base image for all stages

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+.gitignore

--- a/.github/workflows/container-image.yml
+++ b/.github/workflows/container-image.yml
@@ -4,6 +4,9 @@ on:
     - main
     tags:
     - 'v*'
+  pull_request:
+    branches:
+    - main
 
 name: build container image
 
@@ -33,12 +36,32 @@ jobs:
         if: ${{ startsWith(github.ref, 'refs/heads/') }}
         uses: docker/build-push-action@v2
         with:
+          build-args: |
+            PROFILE=debug
           context: .
           file: ./Dockerfile
-          platforms: linux/amd64, linux/arm64
+          platforms: linux/amd64
           push: true
           tags: |
             ghcr.io/rancher-sandbox/lockc:latest
+      -
+        name: Retrieve pull request number
+        if: ${{ startsWith(github.ref, 'refs/pull/') }}
+        run: |
+          echo PR_NUMBER=$(echo $GITHUB_REF | sed -e "s|^refs/pull/||" -e "s|/merge$||")
+      -
+        name: Build and push pull request container image
+        if: ${{ startsWith(github.ref, 'refs/pull/') }}
+        uses: docker/build-push-action@v2
+        with:
+          build-args:
+            PROFILE=debug
+          context: .
+          file: ./Dockerfile
+          platforms: linux/amd64
+          push: true
+          tags: |
+            ghcr.io/rancher-sandbox/lockc:pr${{ env.PR_NUMBER }}
       -
         name: Retrieve tag name
         if: ${{ startsWith(github.ref, 'refs/tags/') }}
@@ -49,6 +72,8 @@ jobs:
         if: ${{ startsWith(github.ref, 'refs/tags/') }}
         uses: docker/build-push-action@v2
         with:
+          build-args: |
+            PROFILE=release
           context: .
           file: ./Dockerfile
           platforms: linux/amd64


### PR DESCRIPTION
We had problems with building based on the official Rust image, based on
Debian. It's more convenient if we just stick to openSUSE and manage all
dependencies ourselves.

This PR also adds container builds for pull requests. For two reasons:

1) In case of failures on the main branch, to check whether a pull request aiming to fix them really fixes them.
2) Might be nice for testing someones' changes before merging, without necessity to check out and build their code.