### PR TITLE
Restrict access to K8s secret token

### DIFF
--- a/contrib/etc/lockc/lockc.toml
+++ b/contrib/etc/lockc/lockc.toml
@@ -379,8 +379,10 @@ allowed_paths_access_baseline = [
 denied_paths_access_restricted = [
     "/proc/acpi",
     "/proc/sys",
+    "/var/run/secrets/kubernetes.io",
 ]
 
 denied_paths_access_baseline = [
     "/proc/acpi",
+    "/var/run/secrets/kubernetes.io",
 ]

--- a/contrib/helm/lockc/templates/configmap.yaml
+++ b/contrib/helm/lockc/templates/configmap.yaml
@@ -1,0 +1,397 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: lockc
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "lockcd.labels" . | nindent 4 }}
+data:
+  lockc.toml: |
+    # Container runtime process names to monitor.
+    runtimes = ["runc"]
+
+    # Paths which are allowed to bind mount from host filesystem to container
+    # filesystem in containers with "restricted" policy.
+    # By default, these are only directories used by container runtimes (i.e. runc),
+    # engines (i.e. containerd, cri-o, podman) and kubelet.
+    allowed_paths_mount_restricted = [
+        # Path to Pseudo-Terminal Device, needed for -it option in container runtimes.
+        "/dev/pts",
+        # Storage directory used by libpod (podman, cri-o).
+        "/var/lib/containers/storage",
+        # Storage directory used by docker (overlay2 driver).
+        "/var/lib/docker/overlay2",
+        # Storage directory used by containerd.
+        "/var/run/container",
+        # Storage directory used by CRI containerd.
+        "/run/containerd/io.containerd.runtime.v1.linux",
+        # Storage directory used by CRI containerd.
+        "/run/containerd/io.containerd.runtime.v2.task",
+        # Data directory used by docker.
+        "/var/lib/docker/containers",
+        # Sandbox directory used by containerd.
+        "/run/containerd/io.containerd.grpc.v1.cri/sandboxes",
+        # Sandbox directory used by containerd.
+        "/var/lib/containerd/io.containerd.grpc.v1.cri/sandboxes",
+        # Misc cgroup controller.
+        "/sys/fs/cgroup/misc",
+        # RDMA controller.
+        "/sys/fs/cgroup/rdma",
+        # Block I/O controller for libpod (podman, cri-o).
+        "/sys/fs/cgroup/blkio/machine.slice",
+        # CPU accounting controller for libpod (podman, cri-o).
+        "/sys/fs/cgroup/cpu,cpuacct/machine.slice",
+        # Cpusets for libpod (podman, cri-o).
+        "/sys/fs/cgroup/cpuset/machine.slice",
+        # Device allowlist controller for libpod (podman, cri-o).
+        "/sys/fs/cgroup/devices/machine.slice",
+        # Cgroup freezer for libpod (podman, cri-o).
+        "/sys/fs/cgroup/freezer/machine.slice",
+        # HugeTLB controller for libpod (podman, cri-o).
+        "/sys/fs/cgroup/hugetlb/machine.slice",
+        # Memory controller for libpod (podman, cri-o).
+        "/sys/fs/cgroup/memory/machine.slice",
+        # Network classifier and priority controller for libpod (podman, cri-o).
+        "/sys/fs/cgroup/net_cls,net_prio/machine.slice",
+        # Perf event controller for libpod (podman, cri-o).
+        "/sys/fs/cgroup/perf_event/machine.slice",
+        # Process number controller for libpod (podman, cri-o).
+        "/sys/fs/cgroup/pids/machine.slice",
+        # Cgroup v1 hierarchy (used by systemd) for libpod (podman, cri-o).
+        "/sys/fs/cgroup/systemd/machine.slice",
+        # Cgroup v2 hierarchy (used by systemd) for libpod (podman, cri-o).
+        "/sys/fs/cgroup/unified/machine.slice",
+        # Block I/O controller for kubelet.
+        "/sys/fs/cgroup/blkio/kubepods.slice",
+        # CPU accounting controller for kubelet.
+        "/sys/fs/cgroup/cpu,cpuacct/kubepods.slice",
+        # Cpusets for libpod for kubelet.
+        "/sys/fs/cgroup/cpuset/kubepods.slice",
+        # Device allowlist controller for kubelet.
+        "/sys/fs/cgroup/devices/kubepods.slice",
+        # Cgroup freezer for kubelet.
+        "/sys/fs/cgroup/freezer/kubepods.slice",
+        # HugeTLB controller for kubelet.
+        "/sys/fs/cgroup/hugetlb/kubepods.slice",
+        # Memory controller for kubelet.
+        "/sys/fs/cgroup/memory/kubepods.slice",
+        # Network classifier and priority controller for kubelet.
+        "/sys/fs/cgroup/net_cls,net_prio/kubepods.slice",
+        # Perf event controller for kubelet.
+        "/sys/fs/cgroup/perf_event/kubepods.slice",
+        # Process number controller for kubelet.
+        "/sys/fs/cgroup/pids/kubepods.slice",
+        # Cgroup v1 hierarchy (used by systemd) for kubelet.
+        "/sys/fs/cgroup/systemd/kubepods.slice",
+        # Cgroup v2 hierarchy (used by systemd) for kubelet.
+        "/sys/fs/cgroup/unified/kubepods.slice",
+        # Block I/O controller for kubelet.
+        "/sys/fs/cgroup/blkio/kubepods-besteffort",
+        # CPU accounting controller for kubelet.
+        "/sys/fs/cgroup/cpu,cpuacct/kubepods-besteffort",
+        # Cpusets for libpod for kubelet.
+        "/sys/fs/cgroup/cpuset/kubepods-besteffort",
+        # Device allowlist controller for kubelet.
+        "/sys/fs/cgroup/devices/kubepods-besteffort",
+        # Cgroup freezer for kubelet.
+        "/sys/fs/cgroup/freezer/kubepods-besteffort",
+        # HugeTLB controller for kubelet.
+        "/sys/fs/cgroup/hugetlb/kubepods-besteffort",
+        # Memory controller for kubelet.
+        "/sys/fs/cgroup/memory/kubepods-besteffort",
+        # Network classifier and priority controller for kubelet.
+        "/sys/fs/cgroup/net_cls,net_prio/kubepods-besteffort",
+        # Perf event controller for kubelet.
+        "/sys/fs/cgroup/perf_event/kubepods-besteffort",
+        # Process number controller for kubelet.
+        "/sys/fs/cgroup/pids/kubepods-besteffort",
+        # Cgroup v1 hierarchy (used by systemd) for kubelet.
+        "/sys/fs/cgroup/systemd/kubepods-besteffort",
+        # Cgroup v2 hierarchy (used by systemd) for kubelet.
+        "/sys/fs/cgroup/unified/kubepods-besteffort",
+        # Block I/O controller for containerd.
+        "/sys/fs/cgroup/blkio/system.slice/containerd.service",
+        # CPU accounting controller for containerd.
+        "/sys/fs/cgroup/cpu,cpuacct/system.slice/containerd.service",
+        # Cpusets for libpod for containerd.
+        "/sys/fs/cgroup/cpuset/system.slice/containerd.service",
+        # Device allowlist controller for containerd.
+        "/sys/fs/cgroup/devices/system.slice/containerd.service",
+        # Cgroup freezer for containerd.
+        "/sys/fs/cgroup/freezer/system.slice/containerd.service",
+        # HugeTLB controller for containerd.
+        "/sys/fs/cgroup/hugetlb/system.slice/containerd.service",
+        # Memory controller for containerd.
+        "/sys/fs/cgroup/memory/system.slice/containerd.service",
+        # Network classifier and priority controller for containerd.
+        "/sys/fs/cgroup/net_cls,net_prio/system.slice/containerd.service",
+        # Perf event controller for containerd.
+        "/sys/fs/cgroup/perf_event/system.slice/containerd.service",
+        # Process number controller for containerd.
+        "/sys/fs/cgroup/pids/system.slice/containerd.service",
+        # Cgroup v1 hierarchy (used by systemd) for containerd.
+        "/sys/fs/cgroup/systemd/system.slice/containerd.service",
+        # Cgroup v2 hierarchy (used by systemd) for containerd.
+        "/sys/fs/cgroup/unified/system.slice/containerd.service",
+        # Block I/O controller for docker.
+        "/sys/fs/cgroup/blkio/docker",
+        # CPU accounting controller for docker.
+        "/sys/fs/cgroup/cpu,cpuacct/docker",
+        # Cpusets for docker.
+        "/sys/fs/cgroup/cpuset/docker",
+        # Device allowlist controller for docker.
+        "/sys/fs/cgroup/devices/docker",
+        # Cgroup freezer for docker.
+        "/sys/fs/cgroup/freezer/docker",
+        # HugeTLB controller for docker.
+        "/sys/fs/cgroup/hugetlb/docker",
+        # Memory controller for docker.
+        "/sys/fs/cgroup/memory/docker",
+        # Network classifier and priority controller for docker.
+        "/sys/fs/cgroup/net_cls,net_prio/docker",
+        # Perf event controller for docker.
+        "/sys/fs/cgroup/perf_event/docker",
+        # Process number controller for docker.
+        "/sys/fs/cgroup/pids/docker",
+        # Cgroup v1 hierarchy (used by systemd) for docker.
+        "/sys/fs/cgroup/systemd/docker",
+        # Cgroup v2 hierarchy (used by systemd) for docker.
+        "/sys/fs/cgroup/unified/docker",
+        # State and ephemeral storage for kubelet.
+        "/var/lib/kubelet/pods",
+    ]
+
+    # Paths which are allowed to bind mount from host filesystem to container
+    # filesystem in containers with "baseline" policy.
+    # By default, these are:
+    # * /home
+    # * /var/data
+    # * directories used by container runtimes, engines and kubelet
+    allowed_paths_mount_baseline = [
+        # Directories used by container runtimes, engines and kubelet.
+
+        # Path to Pseudo-Terminal Device, needed for -it option in container runtimes.
+        "/dev/pts",
+        # Storage directory used by libpod (podman, cri-o).
+        "/var/lib/containers/storage",
+        # Storage directory used by docker (overlay2 driver).
+        "/var/lib/docker/overlay2",
+        # Storage directory used by containerd.
+        "/var/run/container",
+        # Storage directory used by CRI containerd.
+        "/run/containerd/io.containerd.runtime.v1.linux",
+        # Storage directory used by CRI containerd.
+        "/run/containerd/io.containerd.runtime.v2.task",
+        # Data directory used by docker.
+        "/var/lib/docker/containers",
+        # Sandbox directory used by containerd.
+        "/run/containerd/io.containerd.grpc.v1.cri/sandboxes",
+        # Sandbox directory used by containerd.
+        "/var/lib/containerd/io.containerd.grpc.v1.cri/sandboxes",
+        # Misc cgroup controller.
+        "/sys/fs/cgroup/misc",
+        # RDMA controller.
+        "/sys/fs/cgroup/rdma",
+        # Block I/O controller for libpod (podman, cri-o).
+        "/sys/fs/cgroup/blkio/machine.slice",
+        # CPU accounting controller for libpod (podman, cri-o).
+        "/sys/fs/cgroup/cpu,cpuacct/machine.slice",
+        # Cpusets for libpod (podman, cri-o).
+        "/sys/fs/cgroup/cpuset/machine.slice",
+        # Device allowlist controller for libpod (podman, cri-o).
+        "/sys/fs/cgroup/devices/machine.slice",
+        # Cgroup freezer for libpod (podman, cri-o).
+        "/sys/fs/cgroup/freezer/machine.slice",
+        # HugeTLB controller for libpod (podman, cri-o).
+        "/sys/fs/cgroup/hugetlb/machine.slice",
+        # Memory controller for libpod (podman, cri-o).
+        "/sys/fs/cgroup/memory/machine.slice",
+        # Network classifier and priority controller for libpod (podman, cri-o).
+        "/sys/fs/cgroup/net_cls,net_prio/machine.slice",
+        # Perf event controller for libpod (podman, cri-o).
+        "/sys/fs/cgroup/perf_event/machine.slice",
+        # Process number controller for libpod (podman, cri-o).
+        "/sys/fs/cgroup/pids/machine.slice",
+        # Cgroup v1 hierarchy (used by systemd) for libpod (podman, cri-o).
+        "/sys/fs/cgroup/systemd/machine.slice",
+        # Cgroup v2 hierarchy (used by systemd) for libpod (podman, cri-o).
+        "/sys/fs/cgroup/unified/machine.slice",
+        # Block I/O controller for kubelet.
+        "/sys/fs/cgroup/blkio/kubepods.slice",
+        # CPU accounting controller for kubelet.
+        "/sys/fs/cgroup/cpu,cpuacct/kubepods.slice",
+        # Cpusets for libpod for kubelet.
+        "/sys/fs/cgroup/cpuset/kubepods.slice",
+        # Device allowlist controller for kubelet.
+        "/sys/fs/cgroup/devices/kubepods.slice",
+        # Cgroup freezer for kubelet.
+        "/sys/fs/cgroup/freezer/kubepods.slice",
+        # HugeTLB controller for kubelet.
+        "/sys/fs/cgroup/hugetlb/kubepods.slice",
+        # Memory controller for kubelet.
+        "/sys/fs/cgroup/memory/kubepods.slice",
+        # Network classifier and priority controller for kubelet.
+        "/sys/fs/cgroup/net_cls,net_prio/kubepods.slice",
+        # Perf event controller for kubelet.
+        "/sys/fs/cgroup/perf_event/kubepods.slice",
+        # Process number controller for kubelet.
+        "/sys/fs/cgroup/pids/kubepods.slice",
+        # Cgroup v1 hierarchy (used by systemd) for kubelet.
+        "/sys/fs/cgroup/systemd/kubepods.slice",
+        # Cgroup v2 hierarchy (used by systemd) for kubelet.
+        "/sys/fs/cgroup/unified/kubepods.slice",
+        # Block I/O controller for kubelet.
+        "/sys/fs/cgroup/blkio/kubepods-besteffort",
+        # CPU accounting controller for kubelet.
+        "/sys/fs/cgroup/cpu,cpuacct/kubepods-besteffort",
+        # Cpusets for libpod for kubelet.
+        "/sys/fs/cgroup/cpuset/kubepods-besteffort",
+        # Device allowlist controller for kubelet.
+        "/sys/fs/cgroup/devices/kubepods-besteffort",
+        # Cgroup freezer for kubelet.
+        "/sys/fs/cgroup/freezer/kubepods-besteffort",
+        # HugeTLB controller for kubelet.
+        "/sys/fs/cgroup/hugetlb/kubepods-besteffort",
+        # Memory controller for kubelet.
+        "/sys/fs/cgroup/memory/kubepods-besteffort",
+        # Network classifier and priority controller for kubelet.
+        "/sys/fs/cgroup/net_cls,net_prio/kubepods-besteffort",
+        # Perf event controller for kubelet.
+        "/sys/fs/cgroup/perf_event/kubepods-besteffort",
+        # Process number controller for kubelet.
+        "/sys/fs/cgroup/pids/kubepods-besteffort",
+        # Cgroup v1 hierarchy (used by systemd) for kubelet.
+        "/sys/fs/cgroup/systemd/kubepods-besteffort",
+        # Cgroup v2 hierarchy (used by systemd) for kubelet.
+        "/sys/fs/cgroup/unified/kubepods-besteffort",
+        # Block I/O controller for containerd.
+        "/sys/fs/cgroup/blkio/system.slice/containerd.service",
+        # CPU accounting controller for containerd.
+        "/sys/fs/cgroup/cpu,cpuacct/system.slice/containerd.service",
+        # Cpusets for libpod for containerd.
+        "/sys/fs/cgroup/cpuset/system.slice/containerd.service",
+        # Device allowlist controller for containerd.
+        "/sys/fs/cgroup/devices/system.slice/containerd.service",
+        # Cgroup freezer for containerd.
+        "/sys/fs/cgroup/freezer/system.slice/containerd.service",
+        # HugeTLB controller for containerd.
+        "/sys/fs/cgroup/hugetlb/system.slice/containerd.service",
+        # Memory controller for containerd.
+        "/sys/fs/cgroup/memory/system.slice/containerd.service",
+        # Network classifier and priority controller for containerd.
+        "/sys/fs/cgroup/net_cls,net_prio/system.slice/containerd.service",
+        # Perf event controller for containerd.
+        "/sys/fs/cgroup/perf_event/system.slice/containerd.service",
+        # Process number controller for containerd.
+        "/sys/fs/cgroup/pids/system.slice/containerd.service",
+        # Cgroup v1 hierarchy (used by systemd) for containerd.
+        "/sys/fs/cgroup/systemd/system.slice/containerd.service",
+        # Cgroup v2 hierarchy (used by systemd) for containerd.
+        "/sys/fs/cgroup/unified/system.slice/containerd.service",
+        # Block I/O controller for docker.
+        "/sys/fs/cgroup/blkio/docker",
+        # CPU accounting controller for docker.
+        "/sys/fs/cgroup/cpu,cpuacct/docker",
+        # Cpusets for docker.
+        "/sys/fs/cgroup/cpuset/docker",
+        # Device allowlist controller for docker.
+        "/sys/fs/cgroup/devices/docker",
+        # Cgroup freezer for docker.
+        "/sys/fs/cgroup/freezer/docker",
+        # HugeTLB controller for docker.
+        "/sys/fs/cgroup/hugetlb/docker",
+        # Memory controller for docker.
+        "/sys/fs/cgroup/memory/docker",
+        # Network classifier and priority controller for docker.
+        "/sys/fs/cgroup/net_cls,net_prio/docker",
+        # Perf event controller for docker.
+        "/sys/fs/cgroup/perf_event/docker",
+        # Process number controller for docker.
+        "/sys/fs/cgroup/pids/docker",
+        # Cgroup v1 hierarchy (used by systemd) for docker.
+        "/sys/fs/cgroup/systemd/docker",
+        # Cgroup v2 hierarchy (used by systemd) for docker.
+        "/sys/fs/cgroup/unified/docker",
+        # State and ephemeral storage for kubelet.
+        "/var/lib/kubelet/pods",
+
+        # Directories mounted by container engine user.
+
+        "/home",
+        "/var/data",
+    ]
+
+    allowed_paths_access_restricted = [
+        "cgroup:",
+        "ipc:",
+        "mnt:",
+        "net:",
+        "pid:",
+        "pipe:",
+        "time:",
+        "user:",
+        "uts:",
+        "/bin",
+        "/dev/console",
+        "/dev/full",
+        "/dev/null",
+        "/dev/pts",
+        "/dev/tty",
+        "/dev/urandom",
+        "/dev/zero",
+        "/etc",
+        "/home",
+        "/lib",
+        "/lib64",
+        "/pause",
+        "/proc",
+        "/run",
+        "/sys/fs/cgroup",
+        "/sys/kernel/mm",
+        "/tmp",
+        "/usr",
+        "/var",
+    ]
+
+    allowed_paths_access_baseline = [
+        "cgroup:",
+        "ipc:",
+        "mnt:",
+        "net:",
+        "pid:",
+        "pipe:",
+        "time:",
+        "user:",
+        "uts:",
+        "/bin",
+        "/dev/console",
+        "/dev/full",
+        "/dev/null",
+        "/dev/pts",
+        "/dev/tty",
+        "/dev/urandom",
+        "/dev/zero",
+        "/etc",
+        "/home",
+        "/lib",
+        "/lib64",
+        "/pause",
+        "/proc",
+        "/run",
+        "/sys/fs/cgroup",
+        "/sys/kernel/mm",
+        "/tmp",
+        "/usr",
+        "/var",
+    ]
+
+    denied_paths_access_restricted = [
+        "/proc/acpi",
+        "/proc/sys",
+        "/var/run/secrets/kubernetes.io",
+    ]
+
+    denied_paths_access_baseline = [
+        "/proc/acpi",
+        "/var/run/secrets/kubernetes.io",
+    ]

--- a/contrib/helm/lockc/templates/daemonset.yaml
+++ b/contrib/helm/lockc/templates/daemonset.yaml
@@ -29,6 +29,8 @@ spec:
           value: "1"
 {{- end }}
         volumeMounts:
+        - mountPath: /etc/lockc
+          name: lockc-config
         - name: bpffs
           mountPath: /sys/fs/bpf
         - name: bin-runc
@@ -45,6 +47,9 @@ spec:
       tolerations:
       - operator: Exists
       volumes:
+      - configMap:
+          name: lockc
+        name: lockc-config
       - name: bpffs
         hostPath:
           path: /sys/fs/bpf

--- a/lockc/src/settings.rs
+++ b/lockc/src/settings.rs
@@ -207,6 +207,7 @@ static DIR_MM: &str = "/sys/kernel/mm";
 static DIR_TMP: &str = "/tmp";
 static DIR_USR: &str = "/usr";
 static DIR_VAR: &str = "/var";
+static DIR_K8S_SECRETS: &str = "/var/run/secrets/kubernetes.io";
 
 static DIR_PROC_ACPI: &str = "/proc/acpi";
 static DIR_PROC_SYS: &str = "/proc/sys";
@@ -480,11 +481,11 @@ impl Settings {
         )?;
         s.set(
             "denied_paths_access_restricted",
-            vec![DIR_PROC_ACPI.to_string(), DIR_PROC_SYS.to_string()],
+            vec![DIR_PROC_ACPI.to_string(), DIR_PROC_SYS.to_string(), DIR_K8S_SECRETS.to_string()],
         )?;
         s.set(
             "denied_paths_access_baseline",
-            vec![DIR_PROC_ACPI.to_string()],
+            vec![DIR_PROC_ACPI.to_string(), DIR_K8S_SECRETS.to_string()],
         )?;
 
         s.merge(config::File::with_name("/etc/lockc/lockc.toml").required(false))?;


### PR DESCRIPTION
The most of the containerized workloads do not need to interact with the Kubernetes API server and
they don't need to read the token that is associated with the ServiceAccount used to create the Pod.

This path can be blocked /var/run/secrets/kubernetes.io