### PR TITLE
Switch to bitnami/nginx:1.21.4 containers

### DIFF
--- a/examples/kubernetes/deployments-should-fail.yaml
+++ b/examples/kubernetes/deployments-should-fail.yaml
@@ -18,7 +18,7 @@ spec:
     spec:
       containers:
       - name: nginx
-        image: nginx:1.14.2
+        image: bitnami/nginx:1.21.4
         ports:
         - containerPort: 80
         volumeMounts:

--- a/examples/kubernetes/deployments-should-succeed.yaml
+++ b/examples/kubernetes/deployments-should-succeed.yaml
@@ -18,33 +18,32 @@ spec:
     spec:
       containers:
       - name: nginx
-        image: nginx:1.14.2
+        image: bitnami/nginx:1.21.4
         ports:
         - containerPort: 80
 ---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: app-restricted-success
+  name: nginx-restricted-success
   namespace: restricted
 spec:
   selector:
     matchLabels:
-      app: app-restricted-success
+      app: nginx-restricted-success
   replicas: 1
   template:
     metadata:
       labels:
-        app: app-restricted-success
+        app: nginx-restricted-success
     spec:
       securityContext:
         runAsUser: 101
         seccompProfile:
           type: "RuntimeDefault"
       containers:
-      - name: app-restricted
-        image: busybox
-        command: [ "sh", "-c", "sleep 3600" ]
+      - name: nginx
+        image: bitnami/nginx:1.21.4
         ports:
         - containerPort: 80
         securityContext:
@@ -70,7 +69,7 @@ spec:
     spec:
       containers:
       - name: nginx
-        image: nginx:1.14.2
+        image: bitnami/nginx:1.21.4
         ports:
         - containerPort: 80
 ---


### PR DESCRIPTION
Original nginx images can't runAsNonRoot user we have to switch to better tuned
bitnami nginx latest 1.21.4 images. This makes examples running in restricted
namespace for Kubernetes v1.23