### PR TITLE
settings: Add all Docker stoage drivers

### DIFF
--- a/contrib/etc/lockc/lockc.toml
+++ b/contrib/etc/lockc/lockc.toml
@@ -10,8 +10,20 @@ allowed_paths_mount_restricted = [
     "/dev/pts",
     # Storage directory used by libpod (podman, cri-o).
     "/var/lib/containers/storage",
+    # Storage directory used by docker (aufs driver).
+    "/var/lib/docker/aufs",
+    # Storage directory used by docker (btrfs driver).
+    "/var/lib/docker/btrfs",
+    # Storage directory used by docker (devmapper driver).
+    "/var/lib/docker/devmapper",
+    # Storage directory used by docker (overlay driver)
+    "/var/lib/docker/overlay",
     # Storage directory used by docker (overlay2 driver).
     "/var/lib/docker/overlay2",
+    # Storage directory used by docker (vfs driver).
+    "/var/lib/docker/vfs",
+    # Storage directory used by docker (zfs driver).
+    "/var/lib/docker/zfs",
     # Storage directory used by containerd.
     "/var/run/container",
     # Storage directory used by CRI containerd.
@@ -165,8 +177,20 @@ allowed_paths_mount_baseline = [
     "/dev/pts",
     # Storage directory used by libpod (podman, cri-o).
     "/var/lib/containers/storage",
+    # Storage directory used by docker (aufs driver).
+    "/var/lib/docker/aufs",
+    # Storage directory used by docker (btrfs driver).
+    "/var/lib/docker/btrfs",
+    # Storage directory used by docker (devmapper driver).
+    "/var/lib/docker/devmapper",
+    # Storage directory used by docker (overlay driver)
+    "/var/lib/docker/overlay",
     # Storage directory used by docker (overlay2 driver).
     "/var/lib/docker/overlay2",
+    # Storage directory used by docker (vfs driver).
+    "/var/lib/docker/vfs",
+    # Storage directory used by docker (zfs driver).
+    "/var/lib/docker/zfs",
     # Storage directory used by containerd.
     "/var/run/container",
     # Storage directory used by CRI containerd.

--- a/lockc/src/settings.rs
+++ b/lockc/src/settings.rs
@@ -8,8 +8,20 @@ static DIR_PTS: &str = "/dev/pts";
 
 /// Storage directory used by libpod (podman, cri-o).
 static DIR_STORAGE_LIBPOD: &str = "/var/lib/containers/storage";
+/// Storage directory used by docker (aufs driver).
+static DIR_STORAGE_DOCKER_AUFS: &str = "/var/lib/docker/aufs";
+/// Storage directory used by docker (btrfs driver).
+static DIR_STORAGE_DOCKER_BTRFS: &str = "/var/lib/docker/btrfs";
+/// Storage directory used by docker (devmapper driver).
+static DIR_STORAGE_DOCKER_DEVMAPPER: &str = "/var/lib/docker/devmapper";
+/// Storage directory used by docker (overlay driver).
+static DIR_STORAGE_DOCKER_OVERLAY: &str = "/var/lib/docker/overlay";
 /// Storage directory used by docker (overlay2 driver).
 static DIR_STORAGE_DOCKER_OVERLAY2: &str = "/var/lib/docker/overlay2";
+/// Storage directory used by docker (vfs driver).
+static DIR_STORAGE_DOCKER_VFS: &str = "/var/lib/docker/vfs";
+/// Storage directory used by docker (zfs driver).
+static DIR_STORAGE_DOCKER_ZFS: &str = "/var/lib/docker/zfs";
 /// Storage directory used by containerd.
 static DIR_STORAGE_CONTAINERD: &str = "/var/run/container";
 /// Storage directory used by CRI containerd.
@@ -258,7 +270,13 @@ impl Settings {
             vec![
                 DIR_PTS.to_string(),
                 DIR_STORAGE_LIBPOD.to_string(),
+                DIR_STORAGE_DOCKER_AUFS.to_string(),
+                DIR_STORAGE_DOCKER_BTRFS.to_string(),
+                DIR_STORAGE_DOCKER_DEVMAPPER.to_string(),
+                DIR_STORAGE_DOCKER_OVERLAY.to_string(),
                 DIR_STORAGE_DOCKER_OVERLAY2.to_string(),
+                DIR_STORAGE_DOCKER_VFS.to_string(),
+                DIR_STORAGE_DOCKER_ZFS.to_string(),
                 DIR_STORAGE_CONTAINERD.to_string(),
                 DIR_STORAGE_CRI_CONTAINERD.to_string(),
                 DIR_STORAGE_CRI_CONTAINERD2.to_string(),
@@ -336,7 +354,13 @@ impl Settings {
                 // Paths used by container runtimes.
                 DIR_PTS.to_string(),
                 DIR_STORAGE_LIBPOD.to_string(),
+                DIR_STORAGE_DOCKER_AUFS.to_string(),
+                DIR_STORAGE_DOCKER_BTRFS.to_string(),
+                DIR_STORAGE_DOCKER_DEVMAPPER.to_string(),
+                DIR_STORAGE_DOCKER_OVERLAY.to_string(),
                 DIR_STORAGE_DOCKER_OVERLAY2.to_string(),
+                DIR_STORAGE_DOCKER_VFS.to_string(),
+                DIR_STORAGE_DOCKER_ZFS.to_string(),
                 DIR_STORAGE_CONTAINERD.to_string(),
                 DIR_STORAGE_CRI_CONTAINERD.to_string(),
                 DIR_STORAGE_CRI_CONTAINERD2.to_string(),


### PR DESCRIPTION
Before this change, lockc configuration was aware only of overlay2
storage driver in Docker. That was causing all containers using any
other storage driver to be prevented from running by lockc. This change
fixes that by allowing all drivers.

Fixes: #122
Signed-off-by: Michal Rostecki <mrostecki@opensuse.org>