### PR TITLE
Try to reuse pinned BPF maps

### DIFF
--- a/lockc/src/bin/lockcd.rs
+++ b/lockc/src/bin/lockcd.rs
@@ -1,6 +1,5 @@
 use std::{env, path};
 
-use chrono::prelude::*;
 use log::debug;
 use simplelog::{ColorChoice, ConfigBuilder, LevelFilter, TermLogger, TerminalMode};
 
@@ -27,8 +26,6 @@ fn main() -> anyhow::Result<()> {
         lockc::check_bpf_lsm_enabled(sys_lsm_path)?;
     }
 
-    let now = Utc::now();
-    let dirname = now.format("%s").to_string();
     let path_base = std::path::Path::new("/sys")
         .join("fs")
         .join("bpf")
@@ -36,12 +33,8 @@ fn main() -> anyhow::Result<()> {
 
     std::fs::create_dir_all(&path_base)?;
 
-    let path_base_ts = path_base.join(&dirname);
-
-    let _skel = lockc::BpfContext::new(path_base_ts)?;
+    let _skel = lockc::BpfContext::new(path_base)?;
     debug!("initialized BPF skeleton, loaded programs");
-    lockc::cleanup(path_base, &dirname)?;
-    debug!("cleaned up old BPF programs");
 
     lockc::runc::RuncWatcher::new()?.work_loop()?;
 

--- a/lockc/src/bpf/lockc.bpf.c
+++ b/lockc/src/bpf/lockc.bpf.c
@@ -378,16 +378,14 @@ int BPF_PROG(mount_audit, const char *dev_name, const struct path *path,
 	 */
 	switch (policy_level) {
 	case POLICY_LEVEL_RESTRICTED:
-		bpf_for_each_map_elem(&allowed_paths_mount_restricted,
-				      check_paths, &cb, 0);
+		bpf_for_each_map_elem(&ap_mnt_restr, check_paths, &cb, 0);
 		if (cb.found) {
 			bpf_printk("mount: restricted: allow\n");
 			goto out;
 		}
 		break;
 	case POLICY_LEVEL_BASELINE:
-		bpf_for_each_map_elem(&allowed_paths_mount_baseline,
-				      check_paths, &cb, 0);
+		bpf_for_each_map_elem(&ap_mnt_base, check_paths, &cb, 0);
 		if (cb.found) {
 			bpf_printk("mount: baseline: allow\n");
 			goto out;
@@ -470,32 +468,28 @@ int BPF_PROG(open_audit, struct file *file, int ret_prev)
 	 */
 	switch (policy_level) {
 	case POLICY_LEVEL_RESTRICTED:
-		bpf_for_each_map_elem(&denied_paths_access_restricted,
-				      check_paths, &cb, 0);
+		bpf_for_each_map_elem(&ap_acc_restr, check_paths, &cb, 0);
 		if (cb.found) {
 			bpf_printk("open: restricted: deny\n");
 			ret = -EPERM;
 			goto out;
 		}
 		cb.found = false;
-		bpf_for_each_map_elem(&allowed_paths_access_restricted,
-				      check_paths, &cb, 0);
+		bpf_for_each_map_elem(&ap_acc_restr, check_paths, &cb, 0);
 		if (cb.found) {
 			bpf_printk("open: restricted: allow\n");
 			goto out;
 		}
 		break;
 	case POLICY_LEVEL_BASELINE:
-		bpf_for_each_map_elem(&denied_paths_access_baseline,
-				      check_paths, &cb, 0);
+		bpf_for_each_map_elem(&dp_acc_base, check_paths, &cb, 0);
 		if (cb.found) {
 			bpf_printk("open: baseline: deny\n");
 			ret = -EPERM;
 			goto out;
 		}
 		cb.found = false;
-		bpf_for_each_map_elem(&allowed_paths_access_baseline,
-				      check_paths, &cb, 0);
+		bpf_for_each_map_elem(&ap_acc_base, check_paths, &cb, 0);
 		if (cb.found) {
 			bpf_printk("open: baseline: allow\n");
 			goto out;

--- a/lockc/src/bpf/maps.h
+++ b/lockc/src/bpf/maps.h
@@ -39,75 +39,73 @@ struct {
 } processes SEC(".maps");
 
 /*
- * allowed_paths_mount_restricted - BPF map which contains the source path
- * prefixes allowed to bind mount from host to restricted containers. It should
- * contain only paths used by default by container runtimes, not paths mounted
- * with the -v option.
+ * ap_mnt_restr - BPF map which contains the source path prefixes allowed to
+ * bind mount from host to restricted containers. It should contain only
+ * paths used by default by container runtimes, not paths mounted with the -v
+ * option.
  */
 struct {
 	__uint(type, BPF_MAP_TYPE_HASH);
 	__uint(max_entries, PATH_MAX_LIMIT);
 	__type(key, u32);
 	__type(value, struct accessed_path);
-} allowed_paths_mount_restricted SEC(".maps");
+} ap_mnt_restr SEC(".maps");
 
 /*
- * allowed_paths_mount_baseline - BPF map which contains the source path
- * prefixes allowed to bind mount from host to baseline containers. It
- * should contain both paths used by default by container runtimes and
- * paths we allow to mount with -v option.
+ * ap_mnt_base - BPF map which contains the source path prefixes allowed to
+ * bind mount from host to baseline containers. It should contain both paths
+ * used by default by container runtimes and paths we allow to mount with -v
+ * option.
  */
 struct {
 	__uint(type, BPF_MAP_TYPE_HASH);
 	__uint(max_entries, PATH_MAX_LIMIT);
 	__type(key, u32);
 	__type(value, struct accessed_path);
-} allowed_paths_mount_baseline SEC(".maps");
+} ap_mnt_base SEC(".maps");
 
 /*
- * allowed_paths_access_restricted - BPF map which contains the path prefixes
- * allowed to access (open, create, delete, move etc.) inside filesystems of
- * restricted containers.
+ * ap_acc_restr - BPF map which contains the path prefixes allowed to access
+ * (open, create, delete, move etc.) inside filesystems of restricted
+ * containers.
  */
 struct {
 	__uint(type, BPF_MAP_TYPE_HASH);
 	__uint(max_entries, PATH_MAX_LIMIT);
 	__type(key, u32);
 	__type(value, struct accessed_path);
-} allowed_paths_access_restricted SEC(".maps");
+} ap_acc_restr SEC(".maps");
 
 /*
- * allowed_paths_access_baseline - BPF map which contains the path prefixes
- * allowed to access (open, create, delete, move etc.) inside filesystems of
- * baseline containers.
+ * ap_acc_base - BPF map which contains the path prefixes allowed to access
+ * (open, create, delete, move etc.) inside filesystems of baseline containers.
  */
 struct {
 	__uint(type, BPF_MAP_TYPE_HASH);
 	__uint(max_entries, PATH_MAX_LIMIT);
 	__type(key, u32);
 	__type(value, struct accessed_path);
-} allowed_paths_access_baseline SEC(".maps");
+} ap_acc_base SEC(".maps");
 
 /*
- * denied_paths_access_restricted - BPF map which contains the path prefixes
- * denied to access (open, create, delete, move etc.) inside filesystems of
- * restricted containers.
+ * dp_acc_restr - BPF map which contains the path prefixes denied to access
+ * (open, create, delete, move etc.) inside filesystems of restricted
+ * containers.
  */
 struct {
 	__uint(type, BPF_MAP_TYPE_HASH);
 	__uint(max_entries, PATH_MAX_LIMIT);
 	__type(key, u32);
 	__type(value, struct accessed_path);
-} denied_paths_access_restricted SEC(".maps");
+} dp_acc_restr SEC(".maps");
 
 /*
- * denied_paths_access_baseline - BPF map which contains the path prefixes
- * denied to access (open, create, delete, move etc.) inside filesystems of
- * baseline containers.
+ * dp_acc_base - BPF map which contains the path prefixes denied to access
+ * (open, create, delete, move etc.) inside filesystems of baseline containers.
  */
 struct {
 	__uint(type, BPF_MAP_TYPE_HASH);
 	__uint(max_entries, PATH_MAX_LIMIT);
 	__type(key, u32);
 	__type(value, struct accessed_path);
-} denied_paths_access_baseline SEC(".maps");
+} dp_acc_base SEC(".maps");


### PR DESCRIPTION
Before this change, each restart of lockc resulted in loss of data in
BPF maps. After this change, data is persistent as long as the host
system is not rebooted. All maps are pinned to BPPFS and lockc attempts
to reuse them if they're present.

Fixes: #130
Signed-off-by: Michal Rostecki <mrostecki@opensuse.org>