### PR TITLE
Remove `runtimes` map

### DIFF
--- a/lockc/src/bpf/lockc.bpf.c
+++ b/lockc/src/bpf/lockc.bpf.c
@@ -44,21 +44,6 @@ static __always_inline int handle_new_process(struct task_struct *parent,
 	/* Check if parent process is containerized. */
 	struct process *parent_lookup = bpf_map_lookup_elem(&processes, &ppid);
 	if (!parent_lookup) {
-		/* If not, check whether it's a container runtime process. */
-		// const char *comm = BPF_CORE_READ(child, comm);
-		// u32 runtime_key = hash(comm, TASK_COMM_LEN);
-		// u32 *runtime_lookup = bpf_map_lookup_elem(&runtimes,
-		// 					  &runtime_key);
-		// if (runtime_lookup) {
-		// 	/*
-		// 	 * If yes, it means that's an unwrapped container
-		// 	 * runtime process. Deny it.
-		// 	 */
-		// 	bpf_printk("deny: unwrapped runtime process %d: %s\n",
-		// 		   pid,
-		// 		   BPF_CORE_READ(child, comm));
-		// 	return -EPERM;
-		// }
 		return 0;
 	}
 

--- a/lockc/src/bpf/maps.h
+++ b/lockc/src/bpf/maps.h
@@ -4,18 +4,6 @@
 #include "map_structs.h"
 
 /*
- * runtimes - BPF map containing the process names of container runtime init
- * processes (for example: `runc:[2:INIT]` which is the name of every init
- * process for runc).
- */
-struct {
-	__uint(type, BPF_MAP_TYPE_HASH);
-	__uint(max_entries, 16);
-	__type(key, u32);
-	__type(value, u32);
-} runtimes SEC(".maps");
-
-/*
  * containers - BPF map containing the info about a policy which should be
  * enforced on the given container.
  */


### PR DESCRIPTION
That map is not needed anymore. We detect the runtime processes in the
userspace with fanotify, there is no need for any eBPF logic for that.

Signed-off-by: Michal Rostecki <mrostecki@opensuse.org>