### PR TITLE
Add new LSM_HOOK to restrict root user

### DIFF
--- a/lockc/src/load.rs
+++ b/lockc/src/load.rs
@@ -66,6 +66,13 @@ pub fn attach_programs(bpf: &mut Bpf) -> Result<(), AttachError> {
     open_audit.load("file_open", &btf)?;
     open_audit.attach()?;
 
+    let setuid_audit: &mut Lsm = bpf
+        .program_mut("setuid_audit")
+        .ok_or(AttachError::ProgLoad)?
+        .try_into()?;
+    setuid_audit.load("setuid_audit", &btf)?;
+    setuid_audit.attach()?;
+
     Ok(())
 }
 


### PR DESCRIPTION
We have decided to implement new LSH hook which disable root user in container.

Fix #85

Expected output with this feature enabled:

```
opensuse@mjura-dev:~> sudo -i
sudo: PERM_ROOT: setresuid(0, -1, -1): Operation not permitted
sudo: error initializing audit plugin sudoers_audit


opensuse@mjura-dev:~> su - root
Password: 
su: cannot set user id: Operation not permitted
```