### PR TITLE
Ensure that the binary is named lockcd

### DIFF
--- a/lockc/src/bin/lockcd.rs
+++ b/lockc/src/bin/lockcd.rs
@@ -10,19 +10,13 @@ use tokio::{
 use tracing::{debug, error, Level};
 use tracing_subscriber::FmtSubscriber;
 
-mod bpfstructs;
-mod communication;
-mod load;
-mod maps;
-mod runc;
-mod settings;
-mod sysutils;
-
-use communication::EbpfCommand;
-use load::{attach_programs, load_bpf};
-use maps::{add_container, add_process, delete_container, init_allowed_paths};
-use runc::RuncWatcher;
-use sysutils::check_bpf_lsm_enabled;
+use lockc::{
+    communication::EbpfCommand,
+    load::{attach_programs, load_bpf},
+    maps::{add_container, add_process, delete_container, init_allowed_paths},
+    runc::RuncWatcher,
+    sysutils::check_bpf_lsm_enabled,
+};
 
 #[derive(Error, Debug)]
 enum FanotifyError {

--- a/lockc/src/lib.rs
+++ b/lockc/src/lib.rs
@@ -1,0 +1,7 @@
+pub mod bpfstructs;
+pub mod communication;
+pub mod load;
+pub mod maps;
+pub mod runc;
+pub mod settings;
+pub mod sysutils;


### PR DESCRIPTION
In pull request #142 we made a mistake of converting lockc into full
binary crate, therefore renaming lockcd to lockc and removing a
possibility of creating multiple binaries (if there will be a need -
i.e. for some CLI tool).

This change fixes that by creating a bin/ directory with binaries again.

Signed-off-by: Michal Rostecki <mrostecki@opensuse.org>