### PR TITLE
terraform: Disable strict key checking on scp

### DIFF
--- a/contrib/terraform/libvirt/deploy-kubernetes.sh
+++ b/contrib/terraform/libvirt/deploy-kubernetes.sh
@@ -55,7 +55,7 @@ EOF
     ((++i))
 done
 
-scp ${TR_USERNAME}@${MASTER}:/home/${TR_USERNAME}/.kube/config ./admin.conf
+scp -o 'StrictHostKeyChecking no' ${TR_USERNAME}@${MASTER}:/home/${TR_USERNAME}/.kube/config ./admin.conf
 export KUBECONFIG=`pwd`/admin.conf
 kubectl get nodes
 

--- a/contrib/terraform/openstack/deploy-kubernetes.sh
+++ b/contrib/terraform/openstack/deploy-kubernetes.sh
@@ -56,7 +56,7 @@ EOF
     ((++i))
 done
 
-scp ${TR_USERNAME}@${MASTER}:/home/${TR_USERNAME}/.kube/config ./admin.conf
+scp -o 'StrictHostKeyChecking no' ${TR_USERNAME}@${MASTER}:/home/${TR_USERNAME}/.kube/config ./admin.conf
 export KUBECONFIG=`pwd`/admin.conf
 kubectl get nodes
 


### PR DESCRIPTION
Spinning up VMs was sometimes failing on scp (of kubeconfig) due to
strict key check.

Signed-off-by: Michal Rostecki <mrostecki@opensuse.org>