### PR TITLE
Fix lockc on Kubernetes

### DIFF
--- a/docs/src/developers/terraform/libvirt.md
+++ b/docs/src/developers/terraform/libvirt.md
@@ -149,10 +149,11 @@ Then we need to go to the lockc-helm-charts git repository:
 ```bash
 # Go to the main directory of lockc-helm-charts sources
 cd ../lockc-helm-charts
-helm install lockc charts/lockc/ --namespace kube-system \
+kubectl apply -f https://rancher-sandbox.github.io/lockc-helm-charts/namespace.yaml
+helm install lockc charts/lockc/ --namespace lockc \
     --set lockcd.image.repository=ttl.sh/${IMAGE_NAME} \
     --set lockcd.image.tag=30m \
-    --set lockcd.debug.enabled=true
+    --set lockcd.log.level=debug
 ```
 
 Then wait until the `lockcd` DaemonSet is ready:

--- a/lockc/Cargo.toml
+++ b/lockc/Cargo.toml
@@ -17,7 +17,7 @@ anyhow = "1.0"
 aya = { git = "https://github.com/aya-rs/aya", branch = "main", features=["async_tokio"] }
 bindgen = "0.59"
 byteorder = "1.4"
-clap = { version = "3.0", features = ["derive"] }
+clap = { version = "3.0", features = ["derive", "env"] }
 config = { version = "0.11", default-features = false, features = ["toml"] }
 fanotify-rs = { git = "https://github.com/vadorovsky/fanotify-rs", branch = "fix-pid-type" }
 futures = "0.3"

--- a/lockc/src/bin/lockcd.rs
+++ b/lockc/src/bin/lockcd.rs
@@ -144,10 +144,10 @@ async fn ebpf(
 #[derive(Parser, Debug)]
 #[clap(author, version, about, long_about = None)]
 struct Args {
-    #[clap(long, default_value = "info", possible_values = &["trace", "debug", "info", "warn", "error"])]
+    #[clap(long, env="LOCKC_LOG_LEVEL", default_value = "info", possible_values = &["trace", "debug", "info", "warn", "error"])]
     log_level: String,
 
-    #[clap(long, default_value = "text", possible_values = &["json", "text"])]
+    #[clap(long, env="LOCKC_LOG_FMT", default_value = "text", possible_values = &["json", "text"])]
     log_fmt: String,
 }
 


### PR DESCRIPTION
Change to Aya as the eBPF loader in the userpace (#142) broke few things in the Kubernetes integration. This PR fixes them. Best to be reviewed per commit.