### PR TITLE
tokio: Fix the way of using oneshot::Sender

### DIFF
--- a/lockc/src/bin/lockcd.rs
+++ b/lockc/src/bin/lockcd.rs
@@ -81,17 +81,10 @@ async fn ebpf(
                 let res = add_container(&mut bpf, container_id, pid, policy_level);
                 match responder_tx.send(res) {
                     Ok(_) => {}
-                    Err(res2) => match res2 {
-                        Ok(_) => error!(
-                            command = "add_container",
-                            "could not send eBPF command result although the operation was succeessful"
-                        ),
-                        Err(e) => error!(
-                            error = e.to_string().as_str(),
-                            command = "add_container",
-                            "could not execute eBPF command"
-                        ),
-                    },
+                    Err(_) => error!(
+                        command = "add_container",
+                        "could not send eBPF command result although the operation was succeessful"
+                    ),
                 }
             }
             EbpfCommand::DeleteContainer {
@@ -101,17 +94,10 @@ async fn ebpf(
                 let res = delete_container(&mut bpf, container_id);
                 match responder_tx.send(res) {
                     Ok(_) => {}
-                    Err(res2) => match res2 {
-                        Ok(_) => error!(
-                            command = "delete_container",
-                            "could not send eBPF command result although the operation was succeessful"
-                        ),
-                        Err(e) => error!(
-                            error = e.to_string().as_str(),
-                            command = "delete_container",
-                            "could not execute eBPF command"
-                        ),
-                    },
+                    Err(_) => error!(
+                        command = "delete_container",
+                        "could not send eBPF command result although the operation was succeessful"
+                    ),
                 }
             }
             EbpfCommand::AddProcess {
@@ -121,18 +107,11 @@ async fn ebpf(
             } => {
                 let res = add_process(&mut bpf, container_id, pid);
                 match responder_tx.send(res) {
-                    Ok(_) => error!(
+                    Ok(_) => {}
+                    Err(_) => error!(
                         command = "add_proceess",
                         "could not send eBPF command result although the operation was succeessful"
                     ),
-                    Err(res2) => match res2 {
-                        Ok(_) => {}
-                        Err(e) => error!(
-                            error = e.to_string().as_str(),
-                            command = "add_process",
-                            "could not execute eBPF command"
-                        ),
-                    },
                 }
             }
         }


### PR DESCRIPTION
According to docs of tokio::sync::oneshot::Sender.send, that method
"attempts to send a value on this channel, returning it back if it could
not be sent."

Err case of send() is just simply returning the sent value back. Quite
confusing, I was expecting some real error there. But well, according to
the example snippet:

https://docs.rs/tokio/1.16.1/tokio/sync/oneshot/struct.Sender.html#examples-1

we are just logging a custom error there.

Signed-off-by: Michal Rostecki <mrostecki@opensuse.org>