### PR TITLE
bpf: Fix map pinning

### DIFF
--- a/lockc/src/bin/lockcd.rs
+++ b/lockc/src/bin/lockcd.rs
@@ -56,8 +56,6 @@ async fn ebpf(
         .join("bpf")
         .join("lockc");
 
-    std::fs::create_dir_all(&path_base)?;
-
     let mut bpf = load_bpf(&path_base)?;
 
     init_allowed_paths(&mut bpf)?;

--- a/lockc/src/bpf/maps.h
+++ b/lockc/src/bpf/maps.h
@@ -4,15 +4,38 @@
 #include "map_structs.h"
 #include <bpf/bpf_helpers.h>
 
+#define PIN_BY_NAME 1
+
+// NOTE(vadorovsky): The bpf_map_def struct from libbpf doesn't contain the
+// `pinning` field. Aya uses it (for pinning maps, obviously). This kind of
+// structure is used also in Cilium and even in few selftests in the kernel
+// tree[1].
+//
+// [0] https://github.com/cilium/cilium/blob/v1.11.1/bpf/include/bpf/loader.h#L19-L29
+// [1] https://elixir.bootlin.com/linux/v5.16.8/source/samples/bpf/tc_l2_redirect_kern.c#L23
+/*
+ * bpf_elf_map - description of BPF map attributes. Saved in the ELF object.
+ */
+struct bpf_elf_map {
+	u32 type;
+	u32 key_size;
+	u32 value_size;
+	u32 max_entries;
+	u32 flags;
+	u32 id;
+	u32 pinning;
+};
+
 /*
  * containers - BPF map containing the info about a policy which should be
  * enforced on the given container.
  */
-struct bpf_map_def SEC("maps/containers") containers = {
+struct bpf_elf_map SEC("maps/containers") containers = {
 	.type = BPF_MAP_TYPE_HASH,
 	.max_entries = PID_MAX_LIMIT,
 	.key_size = sizeof(struct container_id),
 	.value_size = sizeof(struct container),
+	.pinning = PIN_BY_NAME,
 };
 
 /*
@@ -20,11 +43,12 @@ struct bpf_map_def SEC("maps/containers") containers = {
  * value of this map, which represents the container, is a key of `containers`
  * BPF map, so it can be used immediately for lookups in `containers` map.
  */
-struct bpf_map_def SEC("maps/processes") processes = {
+struct bpf_elf_map SEC("maps/processes") processes = {
 	.type = BPF_MAP_TYPE_HASH,
 	.max_entries = PID_MAX_LIMIT,
 	.key_size = sizeof(pid_t),
 	.value_size = sizeof(struct process),
+	.pinning = PIN_BY_NAME,
 };
 
 /*
@@ -33,11 +57,12 @@ struct bpf_map_def SEC("maps/processes") processes = {
  * paths used by default by container runtimes, not paths mounted with the -v
  * option.
  */
-struct bpf_map_def SEC("maps/ap_mnt_restr") ap_mnt_restr = {
+struct bpf_elf_map SEC("maps/ap_mnt_restr") ap_mnt_restr = {
 	.type = BPF_MAP_TYPE_HASH,
 	.max_entries = PATH_MAX_LIMIT,
 	.key_size = sizeof(u32),
 	.value_size = sizeof(struct accessed_path),
+	.pinning = PIN_BY_NAME,
 };
 
 /*
@@ -46,11 +71,12 @@ struct bpf_map_def SEC("maps/ap_mnt_restr") ap_mnt_restr = {
  * used by default by container runtimes and paths we allow to mount with -v
  * option.
  */
-struct bpf_map_def SEC("maps/ap_mnt_base") ap_mnt_base = {
+struct bpf_elf_map SEC("maps/ap_mnt_base") ap_mnt_base = {
 	.type = BPF_MAP_TYPE_HASH,
 	.max_entries = PATH_MAX_LIMIT,
 	.key_size = sizeof(u32),
 	.value_size = sizeof(struct accessed_path),
+	.pinning = PIN_BY_NAME,
 };
 
 /*
@@ -58,22 +84,24 @@ struct bpf_map_def SEC("maps/ap_mnt_base") ap_mnt_base = {
  * (open, create, delete, move etc.) inside filesystems of restricted
  * containers.
  */
-struct bpf_map_def SEC("maps/ap_acc_restr") ap_acc_restr = {
+struct bpf_elf_map SEC("maps/ap_acc_restr") ap_acc_restr = {
 	.type = BPF_MAP_TYPE_HASH,
 	.max_entries = PATH_MAX_LIMIT,
 	.key_size = sizeof(u32),
 	.value_size = sizeof(struct accessed_path),
+	.pinning = PIN_BY_NAME,
 };
 
 /*
  * ap_acc_base - BPF map which contains the path prefixes allowed to access
  * (open, create, delete, move etc.) inside filesystems of baseline containers.
  */
-struct bpf_map_def SEC("maps/ap_acc_base") ap_acc_base = {
+struct bpf_elf_map SEC("maps/ap_acc_base") ap_acc_base = {
 	.type = BPF_MAP_TYPE_HASH,
 	.max_entries = PATH_MAX_LIMIT,
 	.key_size = sizeof(u32),
 	.value_size = sizeof(struct accessed_path),
+	.pinning = PIN_BY_NAME,
 };
 
 /*
@@ -81,20 +109,22 @@ struct bpf_map_def SEC("maps/ap_acc_base") ap_acc_base = {
  * (open, create, delete, move etc.) inside filesystems of restricted
  * containers.
  */
-struct bpf_map_def SEC("maps/dp_acc_restr") dp_acc_restr = {
+struct bpf_elf_map SEC("maps/dp_acc_restr") dp_acc_restr = {
 	.type = BPF_MAP_TYPE_HASH,
 	.max_entries = PATH_MAX_LIMIT,
 	.key_size = sizeof(u32),
 	.value_size = sizeof(struct accessed_path),
+	.pinning = PIN_BY_NAME,
 };
 
 /*
  * dp_acc_base - BPF map which contains the path prefixes denied to access
  * (open, create, delete, move etc.) inside filesystems of baseline containers.
  */
-struct bpf_map_def SEC("maps/dp_acc_base") dp_acc_base = {
+struct bpf_elf_map SEC("maps/dp_acc_base") dp_acc_base = {
 	.type = BPF_MAP_TYPE_HASH,
 	.max_entries = PATH_MAX_LIMIT,
 	.key_size = sizeof(u32),
 	.value_size = sizeof(struct accessed_path),
+	.pinning = PIN_BY_NAME,
 };

--- a/lockc/src/maps.rs
+++ b/lockc/src/maps.rs
@@ -143,19 +143,31 @@ pub fn add_process(bpf: &mut Bpf, container_id: String, pid: i32) -> Result<(), 
 
 #[cfg(test)]
 mod tests {
+    use tempfile::{Builder, TempDir};
+
     use crate::{bpfstructs::container_policy_level_POLICY_LEVEL_BASELINE, load::load_bpf};
 
     use super::*;
 
+    fn tmp_path_base() -> TempDir {
+        Builder::new()
+            .prefix("lockc-temp")
+            .rand_bytes(5)
+            .tempdir_in("/sys/fs/bpf")
+            .expect("Creating temporary dir in BPFFS failed")
+    }
+
     #[test]
     fn test_init_allowed_paths() {
-        let mut bpf = load_bpf("/sys/fs/bpf/lockc-test").expect("Loading BPF failed");
+        let path_base = tmp_path_base();
+        let mut bpf = load_bpf(path_base).expect("Loading BPF failed");
         init_allowed_paths(&mut bpf).expect("Initializing allowed paths failed");
     }
 
     #[test]
     fn test_add_container() {
-        let mut bpf = load_bpf("/sys/fs/bpf/lockc-test").expect("Loading BPF failed");
+        let path_base = tmp_path_base();
+        let mut bpf = load_bpf(path_base).expect("Loading BPF failed");
         add_container(
             &mut bpf,
             "5833851e673d45fab4d12105bf61c3f4892b2bbf9c12d811db509a4f22475ec9".to_string(),


### PR DESCRIPTION
Aya relies on the `pinning` field in BPF map definitions. libbpf doesn't
provide that field, so instead of using their bpf_map_def struct, here
we define our bpf_elf_map struct which has it.

Our structure is similar to those available in Cilium[0] and some
selftests in the kernel tree[1].

[0] https://github.com/cilium/cilium/blob/v1.11.1/bpf/include/bpf/loader.h#L19-L29
[1] https://elixir.bootlin.com/linux/v5.16.8/source/samples/bpf/tc_l2_redirect_kern.c#L23

Fixes: #169
Signed-off-by: Michal Rostecki <mrostecki@opensuse.org>