### PR TITLE
lockcd: Set default log level to debug when building with debug profile

### DIFF
--- a/lockc/src/bin/lockcd.rs
+++ b/lockc/src/bin/lockcd.rs
@@ -144,7 +144,24 @@ async fn ebpf(
 #[derive(Parser, Debug)]
 #[clap(author, version, about, long_about = None)]
 struct Args {
-    #[clap(long, env="LOCKC_LOG_LEVEL", default_value = "info", possible_values = &["trace", "debug", "info", "warn", "error"])]
+    #[cfg_attr(
+        debug_assertions,
+        clap(
+            long,
+            env="LOCKC_LOG_LEVEL",
+            default_value = "debug",
+            possible_values = &["trace", "debug", "info", "warn", "error"]
+        )
+    )]
+    #[cfg_attr(
+        not(debug_assertions),
+        clap(
+            long,
+            env="LOCKC_LOG_LEVEL",
+            default_value = "info",
+            possible_values = &["trace", "debug", "info", "warn", "error"]
+        )
+    )]
     log_level: String,
 
     #[clap(long, env="LOCKC_LOG_FMT", default_value = "text", possible_values = &["json", "text"])]


### PR DESCRIPTION
To make developer's life easier and don't bother them with using
--log-lever every time. When building with debug profile, we usually
expect debug logs.

Signed-off-by: Michal Rostecki <mrostecki@opensuse.org>