### PR TITLE
docker: Add missing packages for rust-{gdb,lldb} debuggers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -52,7 +52,8 @@ RUN zypper --non-interactive install \
     libselinux1 \
     && zypper clean
 ARG profile=release
-RUN if [[ "$profile" == "debug" ]]; then zypper --non-interactive install gdb lldb; fi
+# Install rust-gdb and rust-lldb for debug profile
+RUN if [[ "$profile" == "debug" ]]; then zypper --non-interactive install gdb lldb python3-lldb rust; fi
 COPY --from=build /usr/local/src/linux/tools/bpf/bpftool/bpftool /usr/sbin/bpftool
 COPY --from=build /usr/local/src/lockc/target/${profile}/lockcd /usr/bin/lockcd
 ENTRYPOINT ["/usr/bin/lockcd"]


### PR DESCRIPTION
rust-gdb and rust-lldb binaries are shipped in rust package. And both of
them need also python3-lldb to work.

Signed-off-by: Michal Rostecki <mrostecki@opensuse.org>