### PR TITLE
Update config to 0.12

### DIFF
--- a/lockc/Cargo.toml
+++ b/lockc/Cargo.toml
@@ -14,11 +14,12 @@ maintenance = { status = "actively-developed" }
 
 [dependencies]
 anyhow = "1.0"
+async-trait = "0.1"
 aya = { git = "https://github.com/aya-rs/aya", branch = "main", features=["async_tokio"] }
 bindgen = "0.59"
 byteorder = "1.4"
 clap = { version = "3.0", features = ["derive", "env"] }
-config = { version = "0.11", default-features = false, features = ["toml"] }
+config = { version = "0.12", default-features = false, features = ["toml"] }
 fanotify-rs = { git = "https://github.com/vadorovsky/fanotify-rs", branch = "fix-pid-type" }
 futures = "0.3"
 kube = "0.68"
@@ -32,7 +33,7 @@ scopeguard = "1.1"
 serde = "1.0"
 serde_json = "1.0"
 thiserror = "1.0"
-tokio = { version = "1.7", features = ["macros", "process", "rt-multi-thread"] }
+tokio = { version = "1.17", features = ["fs", "macros", "process", "rt-multi-thread"] }
 tracing = "0.1"
 tracing-core = "0.1"
 tracing-subscriber = { version = "0.3", features = ["json"] }

--- a/lockc/src/bin/lockcd.rs
+++ b/lockc/src/bin/lockcd.rs
@@ -15,6 +15,7 @@ use lockc::{
     load::{attach_programs, load_bpf},
     maps::{add_container, add_process, delete_container, init_allowed_paths},
     runc::RuncWatcher,
+    settings::new_config,
     sysutils::check_bpf_lsm_enabled,
 };
 
@@ -51,6 +52,8 @@ async fn ebpf(
         check_bpf_lsm_enabled(sys_lsm_path)?;
     }
 
+    let config = new_config().await?;
+
     let path_base = std::path::Path::new("/sys")
         .join("fs")
         .join("bpf")
@@ -58,7 +61,7 @@ async fn ebpf(
 
     let mut bpf = load_bpf(&path_base)?;
 
-    init_allowed_paths(&mut bpf)?;
+    init_allowed_paths(&mut bpf, &config)?;
     debug!("allowed paths initialized");
     attach_programs(&mut bpf)?;
     debug!("attached programs");


### PR DESCRIPTION
That update deprecated the way we used `config` crate. We used to wrap
the whole config into out struct and convert config::Config into it.

After this change, we rather use config::Config directly. We also read
the file in asynchronous way by using AsyncSource trait.

Signed-off-by: Michal Rostecki <vadorovsky@gmail.com>