### PR TITLE
terraform: Fix VM provisioning

### DIFF
--- a/contrib/terraform/libvirt/provision-k8s-containerd-cp.sh
+++ b/contrib/terraform/libvirt/provision-k8s-containerd-cp.sh
@@ -5,5 +5,7 @@ if [ "$(id -u)" != "0" ]; then
   exec sudo "$0" "$@"
 fi
 
+set -eux
+
 HELM_VERSION=$(curl -s https://api.github.com/repos/helm/helm/releases/latest | jq -r '.tag_name')
 curl -sSL "https://get.helm.sh/helm-${HELM_VERSION}-linux-amd64.tar.gz" | sudo tar -C /usr/local/bin --strip-components=1 -xzf - linux-amd64/helm

--- a/contrib/terraform/libvirt/provision-k8s-containerd.sh
+++ b/contrib/terraform/libvirt/provision-k8s-containerd.sh
@@ -5,21 +5,27 @@ if [ "$(id -u)" != "0" ]; then
   exec sudo "$0" "$@"
 fi
 
+set -eux
+
 #CONTAINERD_URL=$(curl -s https://api.github.com/repos/containerd/containerd/releases/latest | jq -r '.assets[] | select(.browser_download_url | contains("cri-containerd-cni") and endswith("linux-amd64.tar.gz")) | .browser_download_url')
 # https://github.com/rancher-sandbox/lockc/issues/178
 # Using latest containerd v1.6.0 will cause following issue 
 # runc: symbol lookup error: runc: undefined symbol: seccomp_notify_respond
-curl -L "${CONTAINERD_URL}" | sudo tar --no-overwrite-dir -C / -xz
+CONTAINERD_URL=https://github.com/containerd/containerd/releases/download/v1.5.9/cri-containerd-cni-1.5.9-linux-amd64.tar.gz
+curl -sSL "${CONTAINERD_URL}" | sudo tar --no-overwrite-dir -C / -xz
 
 systemctl enable containerd
 
 CNI_VERSION=$(curl -s https://api.github.com/repos/containernetworking/plugins/releases/latest | jq -r '.tag_name')
 ARCH="amd64"
 mkdir -p /opt/cni/bin
-curl -L "https://github.com/containernetworking/plugins/releases/download/${CNI_VERSION}/cni-plugins-linux-${ARCH}-${CNI_VERSION}.tgz" | sudo tar -C /opt/cni/bin -xz
+curl -sSL "https://github.com/containernetworking/plugins/releases/download/${CNI_VERSION}/cni-plugins-linux-${ARCH}-${CNI_VERSION}.tgz" | sudo tar -C /opt/cni/bin -xz
 
 DOWNLOAD_DIR=/usr/local/bin
 mkdir -p $DOWNLOAD_DIR
+
+CRICTL_VERSION=$(curl -s https://api.github.com/repos/kubernetes-sigs/cri-tools/releases/latest | jq -r '.tag_name')
+curl -sSL "https://github.com/kubernetes-sigs/cri-tools/releases/download/${CRICTL_VERSION}/crictl-${CRICTL_VERSION}-linux-amd64.tar.gz" | sudo tar -C /usr/local/bin -xz
 
 RELEASE="$(curl -sSL https://dl.k8s.io/release/stable.txt)"
 cd $DOWNLOAD_DIR

--- a/contrib/terraform/openstack/provision-k8s-containerd-cp.sh
+++ b/contrib/terraform/openstack/provision-k8s-containerd-cp.sh
@@ -5,5 +5,7 @@ if [ "$(id -u)" != "0" ]; then
   exec sudo "$0" "$@"
 fi
 
+set -eux
+
 HELM_VERSION=$(curl -s https://api.github.com/repos/helm/helm/releases/latest | jq -r '.tag_name')
 curl -sSL "https://get.helm.sh/helm-${HELM_VERSION}-linux-amd64.tar.gz" | sudo tar -C /usr/local/bin --strip-components=1 -xzf - linux-amd64/helm

--- a/contrib/terraform/openstack/provision-k8s-containerd.sh
+++ b/contrib/terraform/openstack/provision-k8s-containerd.sh
@@ -5,6 +5,8 @@ if [ "$(id -u)" != "0" ]; then
   exec sudo "$0" "$@"
 fi
 
+set -eux
+
 #CONTAINERD_URL=$(curl -s https://api.github.com/repos/containerd/containerd/releases/latest | jq -r '.assets[] | select(.browser_download_url | contains("cri-containerd-cni") and endswith("linux-amd64.tar.gz")) | .browser_download_url')
 # https://github.com/rancher-sandbox/lockc/issues/178
 # Using latest containerd v1.6.0 will cause following issue 
@@ -21,6 +23,9 @@ curl -L "https://github.com/containernetworking/plugins/releases/download/${CNI_
 
 DOWNLOAD_DIR=/usr/local/bin
 mkdir -p $DOWNLOAD_DIR
+
+CRICTRL_VERSION=$(curl -s https://api.github.com/repos/kubernetes-sigs/cri-tools/releases/latest | jq -r '.tag_name')
+curl -L "https://github.com/kubernetes-sigs/cri-tools/releases/download/${CRICTL_VERSION}/crictl-${CRICTL_VERSION}-linux-amd64.tar.gz" | sudo tar -C /usr/local/bin -xz
 
 RELEASE="$(curl -sSL https://dl.k8s.io/release/stable.txt)"
 cd $DOWNLOAD_DIR


### PR DESCRIPTION
* containerd wasn't properly downloaded in lbivirt
* add -sSL option to curl everywhere
* download crictl, which is required by kubeadm now

Signed-off-by: Michal Rostecki <vadorovsky@gmail.com>